### PR TITLE
[oneseo] 병합 셀로 흩어진 실제 생기부 표 형식을 파싱하도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
@@ -31,8 +31,9 @@ import team.themoment.hellogsmv3.domain.oneseo.service.extraction.SubjectNameNor
  * </ul>
  *
  * <p>
- * <b>중요:</b> 아래 정규식들은 실제 생활기록부 샘플 없이 작성한 1차 안입니다. 샘플 PDF를 확보한 뒤 반드시 조정해야 하며,
- * 조정이 필요한 부분은 이 클래스의 상수 영역에 모아두었습니다.
+ * <b>중요:</b> 아래 정규식 · 상태 기계는 실제 생활기록부 원문(PDF 텍스트 레이어 추출 결과)을 대조해 조정한 것입니다. 표의
+ * 병합 셀 때문에 학기 · 성취도 열이 항상 같은 줄에 있지는 않으므로, 줄 하나만 보지 않고 직전까지 읽은 상태를 함께 씁니다. 새로운
+ * 원문 형식이 발견되면 이 클래스의 상수 · 상태 영역을 확인하세요.
  */
 @Component
 @RequiredArgsConstructor
@@ -41,7 +42,7 @@ public class MiddleSchoolRecordParser {
     private final SubjectNameNormalizer subjectNameNormalizer;
 
     // ---------------------------------------------------------------
-    // 실제 샘플 확보 후 조정이 필요한 영역
+    // 새 원문 형식이 발견되면 조정이 필요한 영역
     // ---------------------------------------------------------------
 
     /**
@@ -77,7 +78,23 @@ public class MiddleSchoolRecordParser {
      * group1=학기, group2=과목, group3=성취도
      */
     private static final Pattern SUBJECT_ROW = Pattern.compile(
-            "^([12])\\s+.*(?<![가-힣ㆍ·])([가-힣][가-힣ㆍ·]*)\\s+(?:[\\d.\\s]+/[\\d.\\s]+\\s*(?:\\([^)]*\\))?\\s+)?([A-EP])\\s*(?:\\(\\s*\\d+\\s*\\))?\\s*$");
+            "^(?:([12])\\s+)?.*(?<![가-힣ㆍ·])([가-힣][가-힣ㆍ·]*)\\s+(?:[\\d.,\\s]+/[\\d.,\\s]+\\s*(?:\\([^)]*\\))?\\s+)?([A-EP])\\s*(?:\\(\\s*\\d+\\s*\\))?\\s*[가-힣ㆍ·]{0,3}\\s*$");
+
+    /**
+     * 학기 열이 표의 병합 셀이라 첫 과목 행에만 나오고, 그 뒤로는 줄이 통째로 숫자 하나만 있는 경우가 있습니다. 이럴 땐 이 숫자를 다음
+     * 과목 행들의 학기로 이어받습니다.
+     */
+    private static final Pattern SEMESTER_MARKER = Pattern.compile("^([12])\\s*$");
+
+    /**
+     * 예체능 과목명 행인데 성취도가 같은 줄에 없는 경우. 과목명 행들이 먼저 쭉 나오고, 그 뒤에 성취도 글자들이 같은 순서로 따로 몰려서
+     * 나오는 표가 실제로 있습니다.
+     */
+    private static final Pattern ARTS_PHYSICAL_PENDING_ROW = Pattern
+            .compile("^([12])\\s+(체육|예술\\(음악/미술\\))\\s+([가-힣]+)\\s*$");
+
+    /** 성취도 글자만 홀로 한 줄에 있는 경우. 예체능 과목명이 먼저 밀려 있을 때만 짝을 지어 소비합니다. */
+    private static final Pattern BARE_ACHIEVEMENT = Pattern.compile("^([A-EP])\\s*$");
 
     /**
      * 출결 행. {@code 학년 수업일수 결석(질병/미인정/기타) 지각(3) 조퇴(3) 결과(3)} = 학년 + 수업일수 + 숫자 12개
@@ -89,7 +106,13 @@ public class MiddleSchoolRecordParser {
 
     private static final Pattern ATTENDANCE_PERFECT_ROW = Pattern.compile("^([123])\\s+(\\d+)\\s+개근\\s*$");
 
-    /** 봉사활동 행. 예: {@code 1 봉사활동 7} */
+    /** 학년 + 수업일수만 있고 뒤가 없는 행. "개근"이 다음 줄로 떨어져 나온 경우 대기열에 넣어두고 뒤에서 짝을 맞춥니다. */
+    private static final Pattern GRADE_DAYS_ONLY = Pattern.compile("^([123])\\s+(\\d+)\\s*$");
+
+    /** "개근"만 홀로 한 줄에 있는 경우. */
+    private static final Pattern PERFECT_ATTENDANCE_WORD = Pattern.compile("^개근\\s*$");
+
+    /** 봉사활동 요약 행. 예: {@code 1 봉사활동 7} */
     private static final Pattern VOLUNTEER_ROW = Pattern.compile("^([123])\\s+봉사활동\\s+(\\d+)");
 
     /** 성취도 문자를 성취점수로 변환합니다. 예체능은 A~C(5~3)만 유효합니다. */
@@ -193,15 +216,52 @@ public class MiddleSchoolRecordParser {
             // 이 아래 순회 조건을 바꾸면 개수가 어긋나 범위를 벗어나므로 resolveMarkerGrades도 함께 고쳐야 합니다.
             if (GRADE_MARKER.matcher(line).find()) {
                 currentGrade = markerGrades.get(markerIndex++);
+                context.currentSemester = 0;
             }
 
             if (readAttendance(line, context) || readVolunteer(line, context)) {
                 continue;
             }
             if (currentGrade != 0) {
-                readSubject(line, currentGrade, context);
+                readAcademicRow(line, currentGrade, context);
             }
         }
+    }
+
+    /**
+     * 학기 · 과목 · 성취도 열이 표의 병합 셀 때문에 항상 같은 줄에 붙어 있지는 않아서, 줄 하나만으로 판단하지 않고 직전까지 읽은
+     * 상태(현재 학기, 짝을 기다리는 예체능 과목)를 함께 봅니다.
+     */
+    private void readAcademicRow(String line, int grade, ParseContext context) {
+        Matcher semesterOnly = SEMESTER_MARKER.matcher(line);
+        if (semesterOnly.matches()) {
+            context.currentSemester = Integer.parseInt(semesterOnly.group(1));
+            return;
+        }
+
+        Matcher artsPending = ARTS_PHYSICAL_PENDING_ROW.matcher(line);
+        if (artsPending.matches()) {
+            int semester = Integer.parseInt(artsPending.group(1));
+            context.currentSemester = semester;
+            NormalizedSubject subject = subjectNameNormalizer.normalize(artsPending.group(3));
+            context.pendingArtsPhysical.add(new PendingArtsPhysical(grade + "-" + semester, subject));
+            return;
+        }
+
+        Matcher bareAchievement = BARE_ACHIEVEMENT.matcher(line);
+        if (bareAchievement.matches() && !context.pendingArtsPhysical.isEmpty()) {
+            char letter = bareAchievement.group(1).charAt(0);
+            PendingArtsPhysical pending = context.pendingArtsPhysical.poll();
+            int score = ACHIEVEMENT_SCORE.getOrDefault(letter, NOT_TAKEN);
+            readArtsPhysical(pending.semesterKey(), pending.subject(), score, letter, context);
+            return;
+        }
+
+        readSubject(line, grade, context);
+    }
+
+    /** 성취도가 같은 줄에 없는 예체능 과목 하나를 나타냅니다. 뒤에 따로 나오는 성취도 글자와 순서대로 짝지어집니다. */
+    private record PendingArtsPhysical(String semesterKey, NormalizedSubject subject) {
     }
 
     /**
@@ -269,7 +329,16 @@ public class MiddleSchoolRecordParser {
             return;
         }
 
-        int semester = Integer.parseInt(matcher.group(1));
+        String semesterGroup = matcher.group(1);
+        int semester;
+        if (semesterGroup != null) {
+            semester = Integer.parseInt(semesterGroup);
+            context.currentSemester = semester;
+        } else if (context.currentSemester != 0) {
+            semester = context.currentSemester;
+        } else {
+            return;
+        }
         String rawSubject = matcher.group(2);
         char letter = matcher.group(3).charAt(0);
 
@@ -316,38 +385,89 @@ public class MiddleSchoolRecordParser {
     private boolean readAttendance(String line, ParseContext context) {
         Matcher perfectMatcher = ATTENDANCE_PERFECT_ROW.matcher(line);
         if (perfectMatcher.find()) {
-            int grade = Integer.parseInt(perfectMatcher.group(1));
-            context.absentDays[grade - 1] = 0;
-            context.attendanceDays[(grade - 1) * 3] = 0;
-            context.attendanceDays[(grade - 1) * 3 + 1] = 0;
-            context.attendanceDays[(grade - 1) * 3 + 2] = 0;
+            markPerfectAttendance(Integer.parseInt(perfectMatcher.group(1)), context);
             return true;
         }
 
         Matcher matcher = ATTENDANCE_ROW.matcher(line);
-        if (!matcher.find()) {
-            return false;
+        if (matcher.find()) {
+            int grade = Integer.parseInt(matcher.group(1));
+            int[] values = Arrays.stream(matcher.group(3).strip().split("\\s+")).mapToInt(Integer::parseInt).toArray();
+
+            // 결석 질병/미인정/기타 합산
+            context.absentDays[grade - 1] = values[0] + values[1] + values[2];
+            // 학년별 지각, 조퇴, 결과 순으로 3칸씩 배치
+            context.attendanceDays[(grade - 1) * 3] = values[3] + values[4] + values[5];
+            context.attendanceDays[(grade - 1) * 3 + 1] = values[6] + values[7] + values[8];
+            context.attendanceDays[(grade - 1) * 3 + 2] = values[9] + values[10] + values[11];
+            return true;
         }
 
-        int grade = Integer.parseInt(matcher.group(1));
-        int[] values = Arrays.stream(matcher.group(3).strip().split("\\s+")).mapToInt(Integer::parseInt).toArray();
+        // "학년 수업일수"와 "개근"이 서로 다른 줄로 떨어져 나오는 표가 있습니다. 학년들을 순서대로 대기열에 쌓아두고,
+        // "개근"을 만날 때마다 가장 오래 기다린 학년부터 채웁니다. 문서 안에서 학년은 항상 오름차순으로 나옵니다.
+        if (PERFECT_ATTENDANCE_WORD.matcher(line).matches()) {
+            Integer grade = context.pendingPerfectAttendanceGrades.poll();
+            if (grade != null) {
+                markPerfectAttendance(grade, context);
+            }
+            return true;
+        }
 
-        // 결석 질병/미인정/기타 합산
-        context.absentDays[grade - 1] = values[0] + values[1] + values[2];
-        // 학년별 지각, 조퇴, 결과 순으로 3칸씩 배치
-        context.attendanceDays[(grade - 1) * 3] = values[3] + values[4] + values[5];
-        context.attendanceDays[(grade - 1) * 3 + 1] = values[6] + values[7] + values[8];
-        context.attendanceDays[(grade - 1) * 3 + 2] = values[9] + values[10] + values[11];
-        return true;
+        Matcher daysOnly = GRADE_DAYS_ONLY.matcher(line);
+        if (daysOnly.matches()) {
+            context.pendingPerfectAttendanceGrades.add(Integer.parseInt(daysOnly.group(1)));
+            return true;
+        }
+
+        return false;
+    }
+
+    private void markPerfectAttendance(int grade, ParseContext context) {
+        context.absentDays[grade - 1] = 0;
+        context.attendanceDays[(grade - 1) * 3] = 0;
+        context.attendanceDays[(grade - 1) * 3 + 1] = 0;
+        context.attendanceDays[(grade - 1) * 3 + 2] = 0;
     }
 
     private boolean readVolunteer(String line, ParseContext context) {
-        Matcher matcher = VOLUNTEER_ROW.matcher(line);
-        if (!matcher.find()) {
+        Matcher explicit = VOLUNTEER_ROW.matcher(line);
+        if (explicit.find()) {
+            int grade = Integer.parseInt(explicit.group(1));
+            context.volunteerTime[grade - 1] = Integer.parseInt(explicit.group(2));
+            return true;
+        }
+
+        return readVolunteerLedgerRow(line, context);
+    }
+
+    /**
+     * 봉사활동실적 표는 학년별 합계 줄이 따로 없고, 날짜별 활동마다 그 시점까지의 누계시간만 적혀 있습니다. 그래서 누계시간이 이전 줄보다
+     * 작아지는 시점을 학년이 바뀐 지점으로 보고, 그 학년의 마지막(가장 큰) 누계시간을 총 봉사시간으로 씁니다.
+     *
+     * <p>
+     * 학년 열 자체는 표의 병합 셀이라 실제 학년 경계와 다른 위치에 찍혀 있는 경우가 있어 신뢰할 수 없고, 그래서 사용하지 않습니다.
+     */
+    private boolean readVolunteerLedgerRow(String line, ParseContext context) {
+        String[] tokens = line.split("\\s+");
+        if (tokens.length < 3) {
             return false;
         }
-        int grade = Integer.parseInt(matcher.group(1));
-        context.volunteerTime[grade - 1] = Integer.parseInt(matcher.group(2));
+
+        String hoursToken = tokens[tokens.length - 2];
+        String cumulativeToken = tokens[tokens.length - 1];
+        if (!hoursToken.matches("\\d+") || !cumulativeToken.matches("\\d+")) {
+            return false;
+        }
+
+        int cumulative = Integer.parseInt(cumulativeToken);
+        if (cumulative < context.lastVolunteerCumulative) {
+            context.volunteerSegmentIndex++;
+        }
+        context.lastVolunteerCumulative = cumulative;
+
+        if (context.volunteerSegmentIndex < context.volunteerTime.length) {
+            context.volunteerTime[context.volunteerSegmentIndex] = cumulative;
+        }
         return true;
     }
 
@@ -479,5 +599,11 @@ public class MiddleSchoolRecordParser {
         private final Integer[] absentDays = new Integer[3];
         private final Integer[] attendanceDays = new Integer[9];
         private final Integer[] volunteerTime = new Integer[3];
+        // 학기 열이 병합 셀이라 첫 과목 행에만 나올 때, 뒤이은 행들이 이어받을 학기입니다. 0이면 아직 모르는 상태입니다.
+        private int currentSemester;
+        private final Deque<Integer> pendingPerfectAttendanceGrades = new ArrayDeque<>();
+        private final Deque<PendingArtsPhysical> pendingArtsPhysical = new ArrayDeque<>();
+        private int volunteerSegmentIndex;
+        private int lastVolunteerCumulative;
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
@@ -329,10 +329,10 @@ public class MiddleSchoolRecordParser {
             return;
         }
 
-        String semesterGroup = matcher.group(1);
+        String semesterDigit = matcher.group(1);
         int semester;
-        if (semesterGroup != null) {
-            semester = Integer.parseInt(semesterGroup);
+        if (semesterDigit != null) {
+            semester = Integer.parseInt(semesterDigit);
             context.currentSemester = semester;
         } else if (context.currentSemester != 0) {
             semester = context.currentSemester;
@@ -467,6 +467,11 @@ public class MiddleSchoolRecordParser {
 
         if (context.volunteerSegmentIndex < context.volunteerTime.length) {
             context.volunteerTime[context.volunteerSegmentIndex] = cumulative;
+        } else if (!context.volunteerOverflowWarned) {
+            context.volunteerOverflowWarned = true;
+            context.warnings.add(
+                    ExtractionWarningResDto.builder().field("volunteerTime").type(ExtractionWarningType.OUT_OF_RANGE)
+                            .message("봉사활동 누계시간이 3개 학년보다 더 많은 구간으로 끊겨서 일부를 읽지 못했습니다. 직접 확인해주세요.").build());
         }
         return true;
     }
@@ -605,5 +610,6 @@ public class MiddleSchoolRecordParser {
         private final Deque<PendingArtsPhysical> pendingArtsPhysical = new ArrayDeque<>();
         private int volunteerSegmentIndex;
         private int lastVolunteerCumulative;
+        private boolean volunteerOverflowWarned;
     }
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
@@ -218,6 +218,147 @@ class MiddleSchoolRecordParserTest {
         }
 
         @Nested
+        @DisplayName("학기 열이 병합 셀이라 첫 과목 행에만 있고 원점수에 쉼표 소수점이 섞인 경우")
+        class Context_with_merged_semester_cell_and_comma_decimal {
+
+            private static final String TEXT_WITH_MERGED_SEMESTER = """
+                    교과학습발달상황
+                    [1학년]
+                    학기 교과 과목 원점수/과목평균(표준편차) 성취도(수강자수) 비고
+                    1 국어 국어 91/77,8 A(168)
+                    사회(역사포함)/도 도덕 88/72.0 B(168) 덕
+                    수학 수학 85/70 5 C(168)
+                    """;
+
+            private ExtractedAchievementResDto result;
+
+            @BeforeEach
+            void setUp() {
+                result = new MiddleSchoolRecordParser(new SubjectNameNormalizer()).parse(
+                        new ExtractedTextDto(TEXT_WITH_MERGED_SEMESTER, 1, true, ExtractionSource.TEXT_LAYER, 1.0),
+                        GraduationType.CANDIDATE,
+                        MiddleSchoolRecordParser.FREE_SEMESTER_SYSTEM);
+            }
+
+            @Test
+            @DisplayName("학기 숫자가 없는 뒤 행들도 직전 학기로 채운다")
+            void it_carries_over_semester_to_rows_without_leading_digit() {
+                // 순서: 국어, 사회, 도덕, 역사, 수학, 과학, 기술가정, 정보, 영어
+                assertThat(result.achievement().achievement1_1()).containsExactly(5, 0, 4, 0, 3, 0, 0, 0, 0);
+            }
+        }
+
+        @Nested
+        @DisplayName("학년 · 수업일수와 개근이 서로 다른 줄로 떨어진 출결이 주어진 경우")
+        class Context_with_perfect_attendance_split_across_lines {
+
+            private static final String TEXT_WITH_SPLIT_PERFECT_ATTENDANCE = """
+                    교과학습발달상황
+                    [1학년]
+                    학기 교과 과목 원점수/과목평균(표준편차) 성취도(수강자수) 비고
+                    1 국어 국어 P
+                    출결상황
+                    1 190
+                    2 191
+                    개근
+                    개근
+                    """;
+
+            private ExtractedAchievementResDto result;
+
+            @BeforeEach
+            void setUp() {
+                result = new MiddleSchoolRecordParser(new SubjectNameNormalizer())
+                        .parse(new ExtractedTextDto(TEXT_WITH_SPLIT_PERFECT_ATTENDANCE,
+                                1,
+                                true,
+                                ExtractionSource.TEXT_LAYER,
+                                1.0), GraduationType.CANDIDATE, MiddleSchoolRecordParser.FREE_SEMESTER_SYSTEM);
+            }
+
+            @Test
+            @DisplayName("먼저 나온 학년부터 순서대로 개근을 짝지어 채운다")
+            void it_pairs_perfect_attendance_in_order() {
+                assertThat(result.achievement().absentDays()).containsExactly(0, 0, null);
+                assertThat(result.achievement().attendanceDays()).containsExactly(0, 0, 0, 0, 0, 0, null, null, null);
+            }
+        }
+
+        @Nested
+        @DisplayName("봉사활동이 요약 없이 날짜별 누계시간 기록으로만 주어진 경우")
+        class Context_with_volunteer_ledger_only {
+
+            private static final String TEXT_WITH_VOLUNTEER_LEDGER = """
+                    창의적 체험활동상황
+                    봉사활동실적
+                    일자 또는 기간 장소 또는 주관기관명 활동내용 시간 누계시간
+                    2021.03.02. 환경정화활동 1 1
+                    2021.04.03. 환경정화활동 1 2
+                    2022.03.02. 환경정화활동 1 1
+                    2022.04.03. 환경정화활동 4 5
+                    2023.03.02. 환경정화활동 1 1
+                    2023.04.03. 환경정화활동 8 9
+                    """;
+
+            private ExtractedAchievementResDto result;
+
+            @BeforeEach
+            void setUp() {
+                result = new MiddleSchoolRecordParser(new SubjectNameNormalizer()).parse(
+                        new ExtractedTextDto(TEXT_WITH_VOLUNTEER_LEDGER, 1, true, ExtractionSource.TEXT_LAYER, 1.0),
+                        GraduationType.CANDIDATE,
+                        MiddleSchoolRecordParser.FREE_SEMESTER_SYSTEM);
+            }
+
+            @Test
+            @DisplayName("누계시간이 앞줄보다 줄어드는 지점을 학년 경계로 보고 학년별 총 시간을 채운다")
+            void it_derives_volunteer_time_from_cumulative_resets() {
+                assertThat(result.achievement().volunteerTime()).containsExactly(2, 5, 9);
+            }
+        }
+
+        @Nested
+        @DisplayName("예체능 과목명 행들과 성취도 글자들이 서로 다른 줄 뭉치로 떨어진 경우")
+        class Context_with_arts_physical_split_from_achievement {
+
+            private static final String TEXT_WITH_SPLIT_ARTS_PHYSICAL = """
+                    교과학습발달상황
+                    [1학년]
+                    학기 교과 과목 원점수/과목평균(표준편차) 성취도(수강자수) 비고
+                    1 국어 국어 P
+                    과목 학기 교과 과목
+                    1 체육 체육
+                    1 예술(음악/미술) 음악
+                    2 체육 체육
+                    성취도
+                    A
+                    B
+                    C
+                    비고
+                    """;
+
+            private ExtractedAchievementResDto result;
+
+            @BeforeEach
+            void setUp() {
+                result = new MiddleSchoolRecordParser(new SubjectNameNormalizer()).parse(
+                        new ExtractedTextDto(TEXT_WITH_SPLIT_ARTS_PHYSICAL, 1, true, ExtractionSource.TEXT_LAYER, 1.0),
+                        GraduationType.CANDIDATE,
+                        MiddleSchoolRecordParser.FREE_SEMESTER_SYSTEM);
+            }
+
+            @Test
+            @DisplayName("과목명이 나온 순서대로 뒤에 몰린 성취도 글자와 짝지어 채운다")
+            void it_pairs_arts_physical_subjects_with_achievements_in_order() {
+                // 학기: 1-1, 1-2, 2-1, 2-2, 3-1. 1-1(체육 A, 음악 B) → 인덱스 0,1 / 1-2(체육 C) → 인덱스 3
+                List<Integer> arts = result.achievement().artsPhysicalAchievement();
+                assertThat(arts.get(0)).isEqualTo(5);
+                assertThat(arts.get(1)).isEqualTo(4);
+                assertThat(arts.get(3)).isEqualTo(3);
+            }
+        }
+
+        @Nested
         @DisplayName("자유학기제 졸업예정자의 생활기록부가 주어진 경우")
         class Context_with_free_semester_candidate {
 


### PR DESCRIPTION
## 배경

프론트에서 실제 생기부 PDF의 원문(rawText)을 공유해줘서, 짐작이 아니라 직접 파서에 넣고 진단 테스트(`RecordExtractionDiagnosticTest`)로 확인한 뒤 고쳤습니다.

실제 원문은 표의 학기/학년 열이 병합 셀이라 첫 행에만 나오고, 이후 행들은 그 값이 생략된 채로 이어지는 형식이었습니다. 기존 파서는 매 행이 자기 완결적이라고 가정하고 있어서 이런 형식과 안 맞았습니다.

## 확인 · 수정한 문제

1. **학기 숫자가 첫 과목 행에만 있고 생략됨** — `사회(역사포함)/도 도덕 93/77.6 A(66)` 처럼 학기 숫자 없이 이어지는 행들이 통째로 유실되어 `2-1` 학기가 전부 `null`로 나왔습니다. 직전에 읽은 학기를 이어받도록 수정.
2. **원점수 쉼표 소수점** — `77/62,3` 처럼 점 대신 쉼표가 쓰인 경우 정규식이 깨졌습니다. 허용하도록 수정.
3. **성취도 뒤에 남는 조각 글자** — 표 셀이 줄바꿈으로 쪼개지면서 `A(66) 덕`처럼 성취도 뒤에 다음 셀의 조각이 붙는 경우가 있어, 소량의 트레일링 한글을 허용.
4. **개근이 별도 줄로 분리** — `1 190` / `개근`이 서로 다른 줄에 있는 경우 인식하지 못했습니다(같은 줄 형식만 지원했던 이전 수정으로는 부족). 학년들을 대기열에 쌓아두고 "개근"을 만날 때마다 순서대로 짝짓도록 수정.
5. **봉사활동실적에 학년별 요약 줄이 없음** — 날짜별 활동 기록과 누계시간만 있고 "학년 봉사활동 N시간" 같은 요약 줄 자체가 없었습니다. 누계시간이 앞줄보다 작아지는 지점을 학년 경계로 보고, 각 구간의 마지막(가장 큰) 누계시간을 학년별 총 봉사시간으로 사용하도록 수정.
6. **예체능 과목명과 성취도가 완전히 분리된 표** — 과목명 행들이 먼저 쭉 나오고, 성취도 글자들이 그 뒤에 같은 순서로 몰려서 나오는 표가 있었습니다. 과목명을 대기열에 넣어두고 순서대로 성취도와 짝짓도록 수정.

## 검증

- 실제 원문을 `RecordExtractionDiagnosticTest`(`RECORD_TEXT` 환경변수로 실제 파일 지정)에 넣어 돌리고, 출력된 모든 학기 · 과목 · 예체능 · 출결 · 봉사시간 값을 원문과 하나씩 직접 대조해 확인했습니다. confidence가 0.48 → 0.95로 올랐습니다.
- `MiddleSchoolRecordParserTest`에 이번에 고친 4가지 케이스(병합 셀+쉼표, 개근 줄바꿈, 봉사활동 누계시간, 예체능 분리 표)를 합성 데이터로 재현하는 테스트를 추가했습니다.
- 실제 원문 파일은 개인정보를 포함하므로 저장소에는 커밋하지 않았고, 확인 후 로컬에서 삭제했습니다.

## 참고

이번에 확인 과정에서 이전에 의심했던 "학년 마커 매핑이 뒤섞여 값이 다른 학년으로 들어간다"는 가설은 이 실제 원문 기준으로는 재현되지 않아 폐기했습니다(마커 자체는 `[1학년]`/`[2학년]`/`[3학년]` 순서대로 정상 매칭됨). 실제 원인은 위 6가지였습니다.