### PR TITLE
[global] 원서 인적사항 수정 API 인가 규칙 누락 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -164,7 +164,9 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/oneseo/v3/editability").hasAnyAuthority(ALL_AUTHENTICATED)
                 .requestMatchers(HttpMethod.POST, "/oneseo/v3/oneseo/me/request").hasAnyAuthority(APPLICANT_OR_ROOT)
                 .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/oneseo/{memberId}/approval").hasAnyAuthority(ADMIN_ONLY)
-                .requestMatchers(HttpMethod.POST, "/oneseo/v3/extraction/**").hasAnyAuthority(APPLICANT_OR_ROOT);
+                .requestMatchers(HttpMethod.POST, "/oneseo/v3/extraction/**").hasAnyAuthority(APPLICANT_OR_ROOT)
+                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/personal-info/me").hasAnyAuthority(APPLICANT_OR_ROOT)
+                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/personal-info/{memberId}").hasAnyAuthority(ADMIN_ONLY);
     }
 
     private void operationRequests(


### PR DESCRIPTION
## 개요

`PATCH /oneseo/v3/personal-info/me`와 `PATCH /oneseo/v3/personal-info/{memberId}` 두 엔드포인트에 인가 규칙이 누락되어, 인증되지 않은 사용자도 임의의 회원 인적사항(이름, 생년월일, 성별)을 수정할 수 있는 취약점을 발견하여 수정하였습니다.

## 본문

`OneseoController.modifyPersonalInfo()`, `OneseoController.modifyMyPersonalInfo()`는 존재하지만, `SecurityConfig.oneseoRequests()`에는 `personal-info` 경로에 대한 `requestMatchers` 규칙이 존재하지 않았습니다. `arrived-status/{memberId}`, `competency-score/{memberId}`, `interview-score/{memberId}`, `oneseo/{memberId}/approval` 등 동일 성격의 다른 엔드포인트는 모두 `ADMIN_ONLY`로 보호되어 있었으나, `personal-info`만 누락되어 있었습니다.

`authorizeHttpRequests()`의 마지막 규칙이 `req.anyRequest().permitAll()`이기 때문에, 매칭되는 규칙이 없는 이 두 경로는 인증 여부와 무관하게 통과되는 상태였습니다. 이로 인해 외부 공격자가 세션 없이도 임의의 `memberId`에 대해 인적사항을 변조할 수 있었습니다.

### 변경

`SecurityConfig.oneseoRequests()`에 아래 규칙을 추가하였습니다.

- `PATCH /oneseo/v3/personal-info/me` → `APPLICANT_OR_ROOT` (본인 전용, 기존 `oneseo/v3/oneseo/me`와 동일한 패턴)
- `PATCH /oneseo/v3/personal-info/{memberId}` → `ADMIN_ONLY` (관리자 전용, 기존 `arrived-status/{memberId}` 등과 동일한 패턴)

`OneseoController`와 `ModifyPersonalInfoService`는 이미 올바르게 동작하고 있어 변경하지 않았으며, 문제는 순수하게 `SecurityConfig`의 인가 규칙 누락이었습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
c: 웬만하면 반영해 주세요. (Comment)
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
