### PR TITLE
[global] Pulumi 기반 상용 인프라 코드 추가 및 CD 워크플로우 OIDC 전환

### DIFF
--- a/.github/workflows/hellogsm-prod-cd.yml
+++ b/.github/workflows/hellogsm-prod-cd.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   CD:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout Code
@@ -50,8 +53,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_PROD_DEPLOY_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload to S3

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ out/
 PR_BODY.md
 /.pr-tmp/
 /.claude/command.log
+
+### Pulumi (infra/) ###
+infra/node_modules/
+infra/bin/
+infra/*.tsbuildinfo

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,11 +4,11 @@ config:
   hellogsm-infra:keyPairName: hello-prod-ec2-key
   hellogsm-infra:dbUsername: hellogsm
   # dbPassword는 pulumi config set --secret으로 암호화 저장됨 (아래 secure 값)
+
   hellogsm-infra:dbName: hellogsm
   hellogsm-infra:dbInstanceClass: db.t3.micro
   hellogsm-infra:dbAllocatedStorage: "20"
   hellogsm-infra:dbEngineVersion: "8.0"
-  hellogsm-infra:bastionInstanceType: t3.micro
   hellogsm-infra:springbootInstanceType: t3.small
   hellogsm-infra:redisInstanceType: t3.micro
   hellogsm-infra:domainName: hellogsm.kr

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -1,0 +1,24 @@
+config:
+  aws:region: ap-northeast-2
+  hellogsm-infra:adminSshCidr: 210.218.52.13/32 # 관리자 접속 IP - 필요 시 교체
+  hellogsm-infra:keyPairName: hello-prod-ec2-key
+  hellogsm-infra:dbUsername: hellogsm
+  # dbPassword는 pulumi config set --secret으로 암호화 저장됨 (아래 secure 값)
+  hellogsm-infra:dbName: hellogsm
+  hellogsm-infra:dbInstanceClass: db.t3.micro
+  hellogsm-infra:dbAllocatedStorage: "20"
+  hellogsm-infra:dbEngineVersion: "8.0"
+  hellogsm-infra:bastionInstanceType: t3.micro
+  hellogsm-infra:springbootInstanceType: t3.small
+  hellogsm-infra:redisInstanceType: t3.micro
+  hellogsm-infra:domainName: hellogsm.kr
+  hellogsm-infra:subdomain: api-prod
+  hellogsm-infra:deploymentBucketName: hellogsm-cicd-bucket
+  hellogsm-infra:appAssetsBucketName: hello-26-prod-bucket
+  hellogsm-infra:actuatorBasePath: /hello-management
+  hellogsm-infra:githubOrg: themoment-team
+  hellogsm-infra:githubRepo: hellogsm-server-25
+  hellogsm-infra:codeDeployTagValue: hello-prod-springboot
+  hellogsm-infra:logRetentionDays: "0"
+  hellogsm-infra:dbPassword:
+    secure: AAABAHOa9yIeOGffhDi/82FbBzystjW7ulSmhQbwQ1BrsQHHn1hlyBSag8DPEg1L38tF34t0R8Iev/tS5xohVw==

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,7 +4,6 @@ config:
   hellogsm-infra:keyPairName: hello-prod-ec2-key
   hellogsm-infra:dbUsername: hellogsm
   # dbPassword는 pulumi config set --secret으로 암호화 저장됨 (아래 secure 값)
-
   hellogsm-infra:dbName: hellogsm
   hellogsm-infra:dbInstanceClass: db.t3.micro
   hellogsm-infra:dbAllocatedStorage: "20"
@@ -22,3 +21,4 @@ config:
   hellogsm-infra:logRetentionDays: "0"
   hellogsm-infra:dbPassword:
     secure: AAABAHOa9yIeOGffhDi/82FbBzystjW7ulSmhQbwQ1BrsQHHn1hlyBSag8DPEg1L38tF34t0R8Iev/tS5xohVw==
+  hellogsm-infra:snsAlarmEmail: themoment.hellogsm@gmail.com

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -17,7 +17,7 @@ config:
   hellogsm-infra:appAssetsBucketName: hello-26-prod-bucket
   hellogsm-infra:actuatorBasePath: /hello-management
   hellogsm-infra:githubOrg: themoment-team
-  hellogsm-infra:githubRepo: hellogsm-server-25
+  hellogsm-infra:githubRepo: hellogsm-server-26
   hellogsm-infra:codeDeployTagValue: hello-prod-springboot
   hellogsm-infra:logRetentionDays: "0"
   hellogsm-infra:dbPassword:

--- a/infra/Pulumi.yaml
+++ b/infra/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: hellogsm-infra
 runtime: nodejs
-description: hellogsm-server-25 production AWS infrastructure (Pulumi IaC)
+description: hellogsm-server-26 production AWS infrastructure (Pulumi IaC)

--- a/infra/Pulumi.yaml
+++ b/infra/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: hellogsm-infra
+runtime: nodejs
+description: hellogsm-server-25 production AWS infrastructure (Pulumi IaC)

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,6 +1,6 @@
 # hellogsm-infra
 
-hellogsm-server-25 **상용(production)** AWS 인프라를 관리하는 Pulumi(TypeScript) 프로젝트.
+hellogsm-server-26 **상용(production)** AWS 인프라를 관리하는 Pulumi(TypeScript) 프로젝트.
 State는 Pulumi Cloud(`gsmthemoment-gmail-com/hellogsm-infra/prod`)에 저장한다. 이 스코프는 Production
 환경만 다루며, Stage/Monitoring 환경과 `hellogsm-prod-ci.yml`, stage 워크플로는 포함하지 않는다.
 
@@ -84,9 +84,35 @@ pulumi import aws:s3/bucketV2:BucketV2 deploymentBucket hellogsm-cicd-bucket
 pulumi import aws:s3/bucketV2:BucketV2 appAssetsBucket hello-26-prod-bucket
 ```
 
+위 목록은 "기존에 살아있던" 리소스만 다룬다. 아래는 이 스택이 **새로 만들면서 이름을 고정**해둔
+리소스들이라, 계정에 동일 이름이 이미 있으면(예: 이전 시도의 잔재) `pulumi up`이 아니라
+`pulumi import`부터 해야 충돌하지 않는다. 특히 OIDC provider는 계정당 URL별 1개만 허용되므로
+반드시 먼저 확인할 것.
+
+```bash
+# 같은 URL의 OIDC provider가 계정에 이미 있으면 EntityAlreadyExists로 실패한다
+aws iam list-open-id-connect-providers
+pulumi import aws:iam/openIdConnectProvider:OpenIdConnectProvider github-actions-oidc <provider-arn>
+
+pulumi import aws:iam/role:Role hello-prod-springboot-ec2-role hello-prod-springboot-ec2-role
+pulumi import aws:iam/role:Role hello-prod-codedeploy-service-role hello-prod-codedeploy-service-role
+pulumi import aws:iam/role:Role hello-prod-github-actions-deploy-role hello-prod-github-actions-deploy-role
+
+pulumi import aws:rds/subnetGroup:SubnetGroup hello-prod-rds-subnet-group hello-prod-rds-subnet-group
+pulumi import aws:sns/topic:Topic hello-prod-alerts <topic-arn>
+pulumi import aws:lb/loadBalancer:LoadBalancer hello-prod-alb <alb-arn>
+pulumi import aws:lb/targetGroup:TargetGroup hello-prod-tg <target-group-arn>
+```
+
 각 import 후 `pulumi preview`로 diff를 확인하고, **`replace`/`delete-create`가 뜨면 절대 `pulumi up`하지 말고**
 코드의 해당 속성(특히 `description`처럼 변경 시 교체가 발생하는 불변 필드)을 실제 값에 맞게 고친다.
 (`hellogsm-nat-sg`의 `description`이 이 문제로 한 번 걸렸던 전례가 있다 — 반드시 실제 값과 동일하게 맞출 것.)
+
+`infra/userdata/bastion-nat.sh`는 어떤 코드에서도 참조되지 않는다 - `compute/bastionNat.ts`는
+기존 NAT 인스턴스를 import만 할 뿐 userData를 지정하지 않는다(지정하면 stop/start가 발생해
+오히려 위험하므로 의도적). DR 절차로 NAT 인스턴스를 **새로** 만드는 경우에만 이 스크립트를
+수동으로 적용해야 한다 - 안 하면 iptables MASQUERADE가 설정되지 않아 프라이빗 서브넷에
+라우트는 있어도 실제 인터넷 접근이 안 된다.
 
 ## 배포
 
@@ -103,6 +129,12 @@ dnsCert(ACM DNS 검증 대기) → alb → codeDeploy(설정 갱신) → monitor
 지워지는 게 기본 동작이 아니라, protect:true 리소스를 만나면 에러로 막힐 뿐 나머지가 지워지는 걸
 막지 못한다. 새로 만든 리소스만 걷어내려면 반드시 `pulumi destroy --exclude-protected`를 사용한다.
 
+RDS(`hello-prod-mysql`)는 `protect:true` 외에 `deletionProtection:true`도 걸려있어, 의도적으로
+지우려면 `pulumi state unprotect`로 protect를 해제한 뒤 **먼저 `deletionProtection: false`로
+코드/config를 바꿔 `pulumi up`을 한 번 돌려야** 실제 삭제가 가능하다(AWS API 레벨 보호라
+Pulumi만으로는 우회할 수 없음). `finalSnapshotIdentifier`가 고정값이라 이전에 같은 이름
+스냅샷을 남긴 적이 있다면 삭제 전에 그 스냅샷부터 지워야 한다.
+
 ## 인프라 생성 후 운영 절차
 
 1. `pulumi stack output rdsEndpointAddress`, `pulumi stack output redisPrivateIp` 확인
@@ -115,8 +147,12 @@ dnsCert(ACM DNS 검증 대기) → alb → codeDeploy(설정 갱신) → monitor
    - `AWS_BUCKET_NAME=hello-26-prod-bucket`, `AWS_REGION`/`AWS_SNS_REGION=ap-northeast-2`
 3. GitHub Repository Variable `AWS_PROD_DEPLOY_ROLE_ARN` = `pulumi stack output githubActionsRoleArn`
 4. `.github/workflows/hellogsm-prod-cd.yml`의 OIDC 전환이 머지되어 있는지 확인
-5. main 브랜치 push 또는 `workflow_dispatch`로 CD 워크플로 실행 → 첫 배포
-6. 검증 통과 후 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` GitHub Secret을 GitHub UI에서 수동 삭제
+5. main 브랜치 push 또는 `workflow_dispatch`로 CD 워크플로 실행 → 첫 배포. OIDC trust policy의
+   `sub` 조건이 `ref:refs/heads/main`으로 고정되어 있으므로, `workflow_dispatch`도 반드시
+   main 브랜치를 대상으로 실행할 것 — 다른 브랜치로 실행하면 `AssumeRoleWithWebIdentity`가 거부된다
+6. **정적 액세스키 삭제는 stage CD가 OIDC로 전환된 뒤에만 진행한다** — `hellogsm-stage-cd.yml`이
+   아직 같은 `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` Secret을 쓰고 있어서, 이 PR의 검증만
+   보고 지금 삭제하면 stage CD가 즉시 깨진다. stage도 OIDC로 전환한 뒤 GitHub UI에서 수동 삭제할 것
 
 ## 검증
 
@@ -126,7 +162,7 @@ dnsCert(ACM DNS 검증 대기) → alb → codeDeploy(설정 갱신) → monitor
 - Redis 인스턴스에서 `docker ps` 확인, Spring Boot 인스턴스에서 `redis-cli -h <redisPrivateIp> ping` → `PONG`
 - CD 워크플로 실행 후 `aws deploy get-deployment --deployment-id <id>` 상태 `Succeeded`
 - `aws elbv2 describe-target-health --target-group-arn <arn>` → `healthy`
-- `curl -I https://api-prod.hellogsm.kr<actuatorBasePath>/health` → `200`
+- `curl -I https://api-prod.hellogsm.kr<actuatorBasePath>/health/liveness` → `200` (ALB 타겟그룹이 보는 것과 동일한 경로)
 - `curl -I http://api-prod.hellogsm.kr` → `301`
 - `aws logs describe-log-streams --log-group-name hellogsm-prod-log`로 로그 유입 확인
 - Spring Boot 컨테이너를 의도적으로 중지해 ALB Unhealthy 알람이 SNS로 발행되는지 확인 후 재기동

--- a/infra/README.md
+++ b/infra/README.md
@@ -138,3 +138,4 @@ dnsCert(ACM DNS 검증 대기) → alb → codeDeploy(설정 갱신) → monitor
 - Stage/Monitoring 환경, `hellogsm-prod-ci.yml`, stage 워크플로는 별도 과제
 - 앱의 `AWS_ACCESS_KEY`/`AWS_SECRET_KEY` 정적 키 → 인스턴스 프로파일 전환은 후속 과제로 남김
 - `hellogsm-nat-sg`가 현재 0.0.0.0/0 전체 허용으로 다소 느슨하게 설정되어 있음 (기존 상태 그대로 흡수) — 보안 강화는 별도 논의 필요
+- RDS `multiAz: false` — 비용 절감을 위한 의도적 선택 (Multi-AZ 전환 시 RDS 비용 약 2배). 고가용성이 필요해지면 별도 논의 후 전환

--- a/infra/README.md
+++ b/infra/README.md
@@ -75,6 +75,11 @@ pulumi import aws:ec2/routeTableAssociation:RouteTableAssociation hello-private-
 pulumi import aws:ec2/securityGroup:SecurityGroup hellogsm-nat-sg <sg-id>
 pulumi import aws:ec2/instance:Instance hello-prod-nat <instance-id>
 pulumi import aws:ec2/eip:Eip hello-prod-eip <allocation-id>
+# 퍼블릭 라우트테이블의 IGW 라우트 - RouteTable에서 인라인 routes를 빼고 분리형 Route로
+# 관리하면서 새로 생긴 리소스. AWS에는 이미 있는 라우트라 import 없이 pulumi up하면
+# RouteAlreadyExists로 실패한다.
+pulumi import aws:ec2/route:Route hello-prod-pub-rtb-a-igw-route '<rtb-id>_0.0.0.0/0'
+pulumi import aws:ec2/route:Route hello-pub-rtb-igw-route '<rtb-id>_0.0.0.0/0'
 pulumi import aws:ec2/route:Route hello-prod-priv-rtb-a-nat-route '<rtb-id>_0.0.0.0/0'
 pulumi import aws:ec2/route:Route hello-prod-priv-rtb-b-nat-route '<rtb-id>_0.0.0.0/0'
 pulumi import aws:cloudwatch/logGroup:LogGroup hellogsm-prod-log hellogsm-prod-log

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,140 @@
+# hellogsm-infra
+
+hellogsm-server-25 **상용(production)** AWS 인프라를 관리하는 Pulumi(TypeScript) 프로젝트.
+State는 Pulumi Cloud(`gsmthemoment-gmail-com/hellogsm-infra/prod`)에 저장한다. 이 스코프는 Production
+환경만 다루며, Stage/Monitoring 환경과 `hellogsm-prod-ci.yml`, stage 워크플로는 포함하지 않는다.
+
+## 현재 상태 (중요)
+
+이 프로젝트를 처음 설계할 때는 "상용 인프라가 전부 삭제됐다"는 전제로 전량 신규 생성을 계획했으나,
+실제로는 아래 리소스들이 예전부터(2024년~) 그대로 남아 운영되고 있었다:
+
+- VPC `hello-vpc`, 서브넷 4개(`hello-prod-public-2a`, `hello-public-subnet-2b`,
+  `hello-prod-private-2a`, `hello-private-subnet-2b`), IGW `hellogsm-igw`, 라우트테이블 4개 + 연결
+- Bastion+NAT 인스턴스 `hello-prod-nat`(운영 중, EIP `hello-prod-eip` 연결) + 보안그룹 `hellogsm-nat-sg`
+- CodeDeploy 애플리케이션 `hellogsm-prod-codedeploy` / 배포그룹 `api-prod-hellogsm-kr` (실제 배포 이력 있음)
+- CloudWatch 로그 그룹 `hellogsm-prod-log` (수백MB~1GB 이상의 실제 운영 로그 보유)
+- S3 버킷 `hellogsm-cicd-bucket`(배포 아티팩트), `hello-26-prod-bucket`(앱 자산)
+
+**이 리소스들은 전부 `pulumi import`로 흡수되어 있고, 코드에서 `protect: true`로 보호된다.**
+`hello-pub-rtb`(2b 퍼블릭 라우트테이블)는 **stage 환경(`hello-dev-public-2a`)과 공유**되므로 특히 주의.
+
+새로 생성/관리하는 것은 RDS MySQL, ALB(+ 리스너/타겟그룹), Spring Boot EC2, Redis EC2, 관련 보안그룹,
+IAM 롤(Spring Boot 인스턴스 프로파일 / CodeDeploy 서비스 롤 / GitHub OIDC 배포 롤), ACM 인증서,
+Route53 레코드, SNS 알람 뿐이다.
+
+## 사전 준비
+
+- Pulumi CLI, Node.js 20+, AWS CLI(자격증명 설정 완료)
+- Pulumi Cloud 계정 (`pulumi login`)
+- `hellogsm.kr` Route53 Hosted Zone이 같은 AWS 계정에 이미 존재 (데이터 소스로만 조회, 신규 생성 안 함)
+
+## Bootstrap (기존 stack에 합류하는 경우)
+
+```bash
+cd infra
+pulumi login
+npm install
+pulumi stack select prod
+pulumi preview   # diff가 없어야 정상 (0 create / 0 replace)
+```
+
+## Config
+
+`Pulumi.prod.yaml`에 실제 운영 값이 커밋되어 있다 (`dbPassword`만 Pulumi가 암호화한 `secure` 값).
+값을 바꿔야 할 때만 아래처럼 갱신한다.
+
+```bash
+pulumi config set adminSshCidr <IP>/32
+pulumi config set --secret dbPassword '<new-password>'
+```
+
+## 재해복구 — 스택을 처음부터 다시 만들어야 하는 경우
+
+새 Pulumi 조직/프로젝트로 마이그레이션하는 등 state를 처음부터 다시 구성해야 한다면,
+"현재 상태" 절에서 언급한 기존 리소스들을 **반드시 먼저 import**해야 한다 (안 하면 `pulumi up`이
+동일 이름/CIDR의 VPC·NAT를 중복 생성하거나, 이미 존재하는 로그 그룹/CodeDeploy 앱 이름 충돌로 실패한다).
+
+```bash
+# VPC / IGW / 서브넷 / 라우트테이블 / 연결 / NAT / SG / EIP / 로그그룹 / CodeDeploy
+# — 정확한 리소스 ID는 AWS 콘솔 또는 `aws ec2 describe-*` 로 먼저 조회할 것
+pulumi import aws:ec2/vpc:Vpc hello-vpc <vpc-id>
+pulumi import aws:ec2/internetGateway:InternetGateway hellogsm-igw <igw-id>
+pulumi import aws:ec2/subnet:Subnet hello-prod-public-2a <subnet-id>
+pulumi import aws:ec2/subnet:Subnet hello-public-subnet-2b <subnet-id>
+pulumi import aws:ec2/subnet:Subnet hello-prod-private-2a <subnet-id>
+pulumi import aws:ec2/subnet:Subnet hello-private-subnet-2b <subnet-id>
+pulumi import aws:ec2/routeTable:RouteTable hello-prod-pub-rtb-a <rtb-id>
+pulumi import aws:ec2/routeTable:RouteTable hello-pub-rtb <rtb-id>
+pulumi import aws:ec2/routeTable:RouteTable hello-prod-priv-rtb-a <rtb-id>
+pulumi import aws:ec2/routeTable:RouteTable hello-prod-priv-rtb-b <rtb-id>
+pulumi import aws:ec2/routeTableAssociation:RouteTableAssociation hello-prod-public-2a-assoc <subnet-id>/<rtb-id>
+pulumi import aws:ec2/routeTableAssociation:RouteTableAssociation hello-public-subnet-2b-assoc <subnet-id>/<rtb-id>
+pulumi import aws:ec2/routeTableAssociation:RouteTableAssociation hello-prod-private-2a-assoc <subnet-id>/<rtb-id>
+pulumi import aws:ec2/routeTableAssociation:RouteTableAssociation hello-private-subnet-2b-assoc <subnet-id>/<rtb-id>
+pulumi import aws:ec2/securityGroup:SecurityGroup hellogsm-nat-sg <sg-id>
+pulumi import aws:ec2/instance:Instance hello-prod-nat <instance-id>
+pulumi import aws:ec2/eip:Eip hello-prod-eip <allocation-id>
+pulumi import aws:ec2/route:Route hello-prod-priv-rtb-a-nat-route '<rtb-id>_0.0.0.0/0'
+pulumi import aws:ec2/route:Route hello-prod-priv-rtb-b-nat-route '<rtb-id>_0.0.0.0/0'
+pulumi import aws:cloudwatch/logGroup:LogGroup hellogsm-prod-log hellogsm-prod-log
+pulumi import aws:codedeploy/application:Application hellogsm-prod-codedeploy hellogsm-prod-codedeploy
+pulumi import aws:codedeploy/deploymentGroup:DeploymentGroup api-prod-hellogsm-kr 'hellogsm-prod-codedeploy:api-prod-hellogsm-kr'
+pulumi import aws:s3/bucketV2:BucketV2 deploymentBucket hellogsm-cicd-bucket
+pulumi import aws:s3/bucketV2:BucketV2 appAssetsBucket hello-26-prod-bucket
+```
+
+각 import 후 `pulumi preview`로 diff를 확인하고, **`replace`/`delete-create`가 뜨면 절대 `pulumi up`하지 말고**
+코드의 해당 속성(특히 `description`처럼 변경 시 교체가 발생하는 불변 필드)을 실제 값에 맞게 고친다.
+(`hellogsm-nat-sg`의 `description`이 이 문제로 한 번 걸렸던 전례가 있다 — 반드시 실제 값과 동일하게 맞출 것.)
+
+## 배포
+
+```bash
+pulumi preview
+pulumi up
+```
+
+새로 생성/갱신되는 리소스는 다음 순서로 자동 처리된다:
+securityGroups/iam/s3 → database(RDS, 10~15분 소요) → compute(Spring Boot, Redis) →
+dnsCert(ACM DNS 검증 대기) → alb → codeDeploy(설정 갱신) → monitoring
+
+**`--exclude-protected` 없이 `pulumi destroy`를 실행하면 안 된다** — protect:true가 아닌 리소스만
+지워지는 게 기본 동작이 아니라, protect:true 리소스를 만나면 에러로 막힐 뿐 나머지가 지워지는 걸
+막지 못한다. 새로 만든 리소스만 걷어내려면 반드시 `pulumi destroy --exclude-protected`를 사용한다.
+
+## 인프라 생성 후 운영 절차
+
+1. `pulumi stack output rdsEndpointAddress`, `pulumi stack output redisPrivateIp` 확인
+2. GitHub Secret `PROD_WEB_YML` 갱신:
+   - `DB_URL=jdbc:mysql://<rdsEndpointAddress>:3306/<dbName>`
+   - `DB_USERNAME` / `DB_PASSWORD` (Pulumi config와 동일 값)
+   - `DB_CLASS_NAME=com.mysql.cj.jdbc.Driver`, `DB_PLATFORM=org.hibernate.dialect.MySQLDialect`
+   - `REDIS_HOST=<redisPrivateIp>`
+   - `ACTUATOR_BASE_PATH`는 Pulumi config의 `actuatorBasePath`(`/hello-management`)와 반드시 동일하게 유지
+   - `AWS_BUCKET_NAME=hello-26-prod-bucket`, `AWS_REGION`/`AWS_SNS_REGION=ap-northeast-2`
+3. GitHub Repository Variable `AWS_PROD_DEPLOY_ROLE_ARN` = `pulumi stack output githubActionsRoleArn`
+4. `.github/workflows/hellogsm-prod-cd.yml`의 OIDC 전환이 머지되어 있는지 확인
+5. main 브랜치 push 또는 `workflow_dispatch`로 CD 워크플로 실행 → 첫 배포
+6. 검증 통과 후 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` GitHub Secret을 GitHub UI에서 수동 삭제
+
+## 검증
+
+- `pulumi preview`/`pulumi up`이 clean하게 끝나는지 확인 (replace/delete 없이 create/update만)
+- Bastion EIP로 SSH 후 `ssh -J`로 Spring Boot/Redis 프라이빗 인스턴스 접근 확인, 프라이빗 인스턴스에서 아웃바운드 인터넷(NAT 경유) 동작 확인
+- `mysql -h <rdsEndpoint> -u <dbUsername> -p` 접속 확인
+- Redis 인스턴스에서 `docker ps` 확인, Spring Boot 인스턴스에서 `redis-cli -h <redisPrivateIp> ping` → `PONG`
+- CD 워크플로 실행 후 `aws deploy get-deployment --deployment-id <id>` 상태 `Succeeded`
+- `aws elbv2 describe-target-health --target-group-arn <arn>` → `healthy`
+- `curl -I https://api-prod.hellogsm.kr<actuatorBasePath>/health` → `200`
+- `curl -I http://api-prod.hellogsm.kr` → `301`
+- `aws logs describe-log-streams --log-group-name hellogsm-prod-log`로 로그 유입 확인
+- Spring Boot 컨테이너를 의도적으로 중지해 ALB Unhealthy 알람이 SNS로 발행되는지 확인 후 재기동
+- GitHub Actions 로그에서 정적 키가 아닌 `role-to-assume`(OIDC) 방식으로 인증되는지 확인
+
+## 알려진 스코프 제외 사항
+
+- Discord 웹훅 연동(CloudWatch → Discord)은 레포에 메커니즘이 없어 이번 범위에서 제외 — SNS Topic까지만 생성
+- Stage/Monitoring 환경, `hellogsm-prod-ci.yml`, stage 워크플로는 별도 과제
+- 앱의 `AWS_ACCESS_KEY`/`AWS_SECRET_KEY` 정적 키 → 인스턴스 프로파일 전환은 후속 과제로 남김
+- `hellogsm-nat-sg`가 현재 0.0.0.0/0 전체 허용으로 다소 느슨하게 설정되어 있음 (기존 상태 그대로 흡수) — 보안 강화는 별도 논의 필요

--- a/infra/README.md
+++ b/infra/README.md
@@ -137,5 +137,4 @@ dnsCert(ACM DNS 검증 대기) → alb → codeDeploy(설정 갱신) → monitor
 - Discord 웹훅 연동(CloudWatch → Discord)은 레포에 메커니즘이 없어 이번 범위에서 제외 — SNS Topic까지만 생성
 - Stage/Monitoring 환경, `hellogsm-prod-ci.yml`, stage 워크플로는 별도 과제
 - 앱의 `AWS_ACCESS_KEY`/`AWS_SECRET_KEY` 정적 키 → 인스턴스 프로파일 전환은 후속 과제로 남김
-- `hellogsm-nat-sg`가 현재 0.0.0.0/0 전체 허용으로 다소 느슨하게 설정되어 있음 (기존 상태 그대로 흡수) — 보안 강화는 별도 논의 필요
 - RDS `multiAz: false` — 비용 절감을 위한 의도적 선택 (Multi-AZ 전환 시 RDS 비용 약 2배). 고가용성이 필요해지면 별도 논의 후 전환

--- a/infra/config.ts
+++ b/infra/config.ts
@@ -1,0 +1,40 @@
+import * as pulumi from "@pulumi/pulumi";
+
+const cfg = new pulumi.Config();
+const awsCfg = new pulumi.Config("aws");
+
+export const config = {
+    region: awsCfg.require("region"),
+
+    adminSshCidr: cfg.require("adminSshCidr"),
+    keyPairName: cfg.require("keyPairName"),
+
+    dbUsername: cfg.require("dbUsername"),
+    dbPassword: cfg.requireSecret("dbPassword"),
+    dbName: cfg.require("dbName"),
+    dbInstanceClass: cfg.get("dbInstanceClass") ?? "db.t3.micro",
+    dbAllocatedStorage: cfg.getNumber("dbAllocatedStorage") ?? 20,
+    dbEngineVersion: cfg.get("dbEngineVersion") ?? "8.0",
+
+    bastionInstanceType: cfg.get("bastionInstanceType") ?? "t3.micro",
+    springbootInstanceType: cfg.get("springbootInstanceType") ?? "t3.small",
+    redisInstanceType: cfg.get("redisInstanceType") ?? "t3.micro",
+
+    domainName: cfg.require("domainName"),
+    subdomain: cfg.require("subdomain"),
+
+    deploymentBucketName: cfg.require("deploymentBucketName"),
+    appAssetsBucketName: cfg.require("appAssetsBucketName"),
+
+    actuatorBasePath: cfg.require("actuatorBasePath"),
+
+    githubOrg: cfg.require("githubOrg"),
+    githubRepo: cfg.require("githubRepo"),
+
+    codeDeployTagValue: cfg.get("codeDeployTagValue") ?? "hello-prod-springboot",
+
+    snsAlarmEmail: cfg.get("snsAlarmEmail"),
+    logRetentionDays: cfg.getNumber("logRetentionDays") ?? 0,
+};
+
+export const fqdn = `${config.subdomain}.${config.domainName}`;

--- a/infra/config.ts
+++ b/infra/config.ts
@@ -7,6 +7,9 @@ export const config = {
     region: awsCfg.require("region"),
 
     adminSshCidr: cfg.require("adminSshCidr"),
+    // springboot/redis(신규 생성) 인스턴스에만 쓰인다. Bastion+NAT는 기존 운영 인스턴스를
+    // import한 것이라 실제 키페어("hello-prod-bastion")가 compute/bastionNat.ts에
+    // 하드코딩되어 있고 이 값을 쓰지 않는다.
     keyPairName: cfg.require("keyPairName"),
 
     dbUsername: cfg.require("dbUsername"),
@@ -16,7 +19,6 @@ export const config = {
     dbAllocatedStorage: cfg.getNumber("dbAllocatedStorage") ?? 20,
     dbEngineVersion: cfg.get("dbEngineVersion") ?? "8.0",
 
-    bastionInstanceType: cfg.get("bastionInstanceType") ?? "t3.micro",
     springbootInstanceType: cfg.get("springbootInstanceType") ?? "t3.small",
     redisInstanceType: cfg.get("redisInstanceType") ?? "t3.micro",
 

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -29,26 +29,42 @@ const bastionNat = createBastionNat(network.prodPublicSubnet2a.id, sg.bastionSg.
 
 // 프라이빗 서브넷(2a, 2b) 모두 인터넷 라우트를 기존 Bastion+NAT 인스턴스로 향하게 한다
 // (실제 운영 중이던 라우팅 구성과 동일). network 모듈 생성 시점엔 bastion 인스턴스 참조가
-// 없어 순환 의존이 발생하므로 여기서 별도 생성한다.
-new aws.ec2.Route("hello-prod-priv-rtb-a-nat-route", {
-    routeTableId: network.prodPrivateRouteTable2a.id,
-    destinationCidrBlock: "0.0.0.0/0",
-    networkInterfaceId: bastionNat.instance.primaryNetworkInterfaceId,
-});
+// 없어 순환 의존이 발생하므로 여기서 별도 생성한다. protect:true로 실수 삭제를 막는다 -
+// 없으면 프라이빗 서브넷의 인터넷 경로가 사라지고 메인 라우트테이블로 폴백한다.
+const natRoute2a = new aws.ec2.Route(
+    "hello-prod-priv-rtb-a-nat-route",
+    {
+        routeTableId: network.prodPrivateRouteTable2a.id,
+        destinationCidrBlock: "0.0.0.0/0",
+        networkInterfaceId: bastionNat.instance.primaryNetworkInterfaceId,
+    },
+    { protect: true },
+);
 
-new aws.ec2.Route("hello-prod-priv-rtb-b-nat-route", {
-    routeTableId: network.prodPrivateRouteTable2b.id,
-    destinationCidrBlock: "0.0.0.0/0",
-    networkInterfaceId: bastionNat.instance.primaryNetworkInterfaceId,
-});
+const natRoute2b = new aws.ec2.Route(
+    "hello-prod-priv-rtb-b-nat-route",
+    {
+        routeTableId: network.prodPrivateRouteTable2b.id,
+        destinationCidrBlock: "0.0.0.0/0",
+        networkInterfaceId: bastionNat.instance.primaryNetworkInterfaceId,
+    },
+    { protect: true },
+);
+
+// springboot/redis는 subnet/sg/instance profile만 참조하고 라우트를 참조하지 않아
+// Pulumi 그래프상 natRoute와 병렬로 생성될 수 있다. 재해복구 시나리오처럼 라우트가 아직
+// 없는 상태에서 인스턴스가 먼저 뜨면 userdata의 dnf install/wget이 인터넷 접근 없이
+// 조용히 실패하므로(set -euxo pipefail) 명시적으로 순서를 고정한다.
+const natRouteDeps = { dependsOn: [natRoute2a, natRoute2b] };
 
 const springboot = createSpringbootServer(
     network.prodPrivateSubnet2a.id,
     sg.springbootSg.id,
     iam.springbootInstanceProfile.name,
+    natRouteDeps,
 );
 
-const redis = createRedisServer(network.prodPrivateSubnet2a.id, sg.redisSg.id);
+const redis = createRedisServer(network.prodPrivateSubnet2a.id, sg.redisSg.id, natRouteDeps);
 
 const dnsCert = createDnsAndCertificate();
 
@@ -61,7 +77,7 @@ const alb = createAlb(
     dnsCert.zone.zoneId,
 );
 
-const codeDeploy = createCodeDeploy(iam.codeDeployServiceRole.arn);
+const codeDeploy = createCodeDeploy(iam.codeDeployServiceRole.arn, alb.targetGroup.name);
 
 const monitoring = createMonitoring(
     alb.targetGroup.arnSuffix,

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -1,0 +1,86 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+import { fqdn } from "./config";
+import { createNetwork } from "./modules/network";
+import { createSecurityGroups } from "./modules/securityGroups";
+import { createS3Buckets } from "./modules/s3";
+import { createIam } from "./modules/iam";
+import { createDatabase } from "./modules/database";
+import { createBastionNat } from "./modules/compute/bastionNat";
+import { createSpringbootServer } from "./modules/compute/springbootServer";
+import { createRedisServer } from "./modules/compute/redisServer";
+import { createDnsAndCertificate } from "./modules/dnsCert";
+import { createAlb } from "./modules/alb";
+import { createCodeDeploy } from "./modules/codeDeploy";
+import { createMonitoring } from "./modules/monitoring";
+
+const network = createNetwork();
+const sg = createSecurityGroups(network.vpc.id);
+const s3 = createS3Buckets();
+const iam = createIam(s3.deploymentBucket.arn, s3.appAssetsBucket.arn);
+const database = createDatabase(
+    network.prodPrivateSubnet2a.id,
+    network.privateSubnet2b.id,
+    sg.rdsSg.id,
+);
+
+const bastionNat = createBastionNat(network.prodPublicSubnet2a.id, sg.bastionSg.id);
+
+// 프라이빗 서브넷(2a, 2b) 모두 인터넷 라우트를 기존 Bastion+NAT 인스턴스로 향하게 한다
+// (실제 운영 중이던 라우팅 구성과 동일). network 모듈 생성 시점엔 bastion 인스턴스 참조가
+// 없어 순환 의존이 발생하므로 여기서 별도 생성한다.
+new aws.ec2.Route("hello-prod-priv-rtb-a-nat-route", {
+    routeTableId: network.prodPrivateRouteTable2a.id,
+    destinationCidrBlock: "0.0.0.0/0",
+    networkInterfaceId: bastionNat.instance.primaryNetworkInterfaceId,
+});
+
+new aws.ec2.Route("hello-prod-priv-rtb-b-nat-route", {
+    routeTableId: network.prodPrivateRouteTable2b.id,
+    destinationCidrBlock: "0.0.0.0/0",
+    networkInterfaceId: bastionNat.instance.primaryNetworkInterfaceId,
+});
+
+const springboot = createSpringbootServer(
+    network.prodPrivateSubnet2a.id,
+    sg.springbootSg.id,
+    iam.springbootInstanceProfile.name,
+);
+
+const redis = createRedisServer(network.prodPrivateSubnet2a.id, sg.redisSg.id);
+
+const dnsCert = createDnsAndCertificate();
+
+const alb = createAlb(
+    [network.prodPublicSubnet2a.id, network.publicSubnet2b.id],
+    sg.albSg.id,
+    network.vpc.id,
+    springboot.instance.id,
+    dnsCert.certificateValidation.certificateArn,
+    dnsCert.zone.zoneId,
+);
+
+const codeDeploy = createCodeDeploy(iam.codeDeployServiceRole.arn);
+
+const monitoring = createMonitoring(
+    alb.targetGroup.arnSuffix,
+    alb.alb.arnSuffix,
+    springboot.instance.id,
+    redis.instance.id,
+);
+
+export const vpcId = network.vpc.id;
+export const albDnsName = alb.alb.dnsName;
+export const apiUrl = pulumi.interpolate`https://${fqdn}`;
+export const rdsEndpointAddress = database.instance.address;
+export const redisPrivateIp = redis.instance.privateIp;
+export const springbootPrivateIp = springboot.instance.privateIp;
+export const bastionPublicIp = bastionNat.eip.publicIp;
+export const deploymentBucketArn = s3.deploymentBucket.arn;
+export const appAssetsBucketArn = s3.appAssetsBucket.arn;
+export const githubActionsRoleArn = iam.githubActionsDeployRole.arn;
+export const codeDeployApplicationName = codeDeploy.application.name;
+export const codeDeployDeploymentGroupName = codeDeploy.deploymentGroup.deploymentGroupName;
+export const cloudWatchLogGroupName = monitoring.logGroup.name;
+export const snsAlertsTopicArn = monitoring.alertsTopic.arn;

--- a/infra/modules/alb.ts
+++ b/infra/modules/alb.ts
@@ -1,0 +1,92 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import { config, fqdn } from "../config";
+
+export interface AlbResult {
+    alb: aws.lb.LoadBalancer;
+    targetGroup: aws.lb.TargetGroup;
+    httpsListener: aws.lb.Listener;
+    httpListener: aws.lb.Listener;
+    dnsRecord: aws.route53.Record;
+}
+
+export function createAlb(
+    publicSubnetIds: pulumi.Input<pulumi.Input<string>[]>,
+    albSgId: aws.ec2.SecurityGroup["id"],
+    vpcId: aws.ec2.Vpc["id"],
+    springbootInstanceId: aws.ec2.Instance["id"],
+    certificateArn: pulumi.Input<string>,
+    zoneId: pulumi.Input<string>,
+): AlbResult {
+    const alb = new aws.lb.LoadBalancer("hello-prod-alb", {
+        name: "hello-prod-alb",
+        internal: false,
+        loadBalancerType: "application",
+        securityGroups: [albSgId],
+        subnets: publicSubnetIds,
+        tags: { Name: "hello-prod-alb" },
+    });
+
+    const targetGroup = new aws.lb.TargetGroup("hello-prod-tg", {
+        name: "hello-prod-tg",
+        port: 8080,
+        protocol: "HTTP",
+        targetType: "instance",
+        vpcId,
+        healthCheck: {
+            enabled: true,
+            path: `${config.actuatorBasePath}/health`,
+            protocol: "HTTP",
+            matcher: "200",
+            interval: 15,
+            timeout: 5,
+            healthyThreshold: 2,
+            unhealthyThreshold: 2,
+        },
+        tags: { Name: "hello-prod-tg" },
+    });
+
+    // 단일 인스턴스 정적 등록 (Auto Scaling Group 아님). CodeDeploy 배포 중
+    // 컨테이너가 stop/start되는 동안 짧은 다운타임이 발생할 수 있음 - 기존 방식과 동일한 트레이드오프.
+    new aws.lb.TargetGroupAttachment("hello-prod-tg-attachment", {
+        targetGroupArn: targetGroup.arn,
+        targetId: springbootInstanceId,
+        port: 8080,
+    });
+
+    const httpsListener = new aws.lb.Listener("hello-prod-alb-listener-443", {
+        loadBalancerArn: alb.arn,
+        port: 443,
+        protocol: "HTTPS",
+        sslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06",
+        certificateArn,
+        defaultActions: [{ type: "forward", targetGroupArn: targetGroup.arn }],
+    });
+
+    const httpListener = new aws.lb.Listener("hello-prod-alb-listener-80", {
+        loadBalancerArn: alb.arn,
+        port: 80,
+        protocol: "HTTP",
+        defaultActions: [
+            {
+                type: "redirect",
+                redirect: { port: "443", protocol: "HTTPS", statusCode: "HTTP_301" },
+            },
+        ],
+    });
+
+    const dnsRecord = new aws.route53.Record("api-prod-alb-alias", {
+        zoneId,
+        name: fqdn,
+        type: "A",
+        aliases: [
+            {
+                name: alb.dnsName,
+                zoneId: alb.zoneId,
+                evaluateTargetHealth: true,
+            },
+        ],
+    });
+
+    return { alb, targetGroup, httpsListener, httpListener, dnsRecord };
+}

--- a/infra/modules/alb.ts
+++ b/infra/modules/alb.ts
@@ -35,7 +35,10 @@ export function createAlb(
         vpcId,
         healthCheck: {
             enabled: true,
-            path: `${config.actuatorBasePath}/health`,
+            // 기본 집계 /health는 db/redis/diskSpace 인디케이터를 전부 포함해 하나만 DOWN이어도
+            // 503이 되고, 인스턴스가 1대뿐이라 곧바로 전체 장애로 이어진다. liveness 그룹으로
+            // 앱 프로세스 생존 여부만 체크한다 (application.yml의 management.endpoint.health.group.liveness).
+            path: `${config.actuatorBasePath}/health/liveness`,
             protocol: "HTTP",
             matcher: "200",
             interval: 15,
@@ -46,8 +49,9 @@ export function createAlb(
         tags: { Name: "hello-prod-tg" },
     });
 
-    // 단일 인스턴스 정적 등록 (Auto Scaling Group 아님). CodeDeploy 배포 중
-    // 컨테이너가 stop/start되는 동안 짧은 다운타임이 발생할 수 있음 - 기존 방식과 동일한 트레이드오프.
+    // 단일 인스턴스 정적 등록 (Auto Scaling Group 아님). CodeDeploy가 WITH_TRAFFIC_CONTROL로
+    // 배포 중 이 타겟을 등록 해제/재등록하지만, 인스턴스가 1대뿐이라 배포 중 다운타임 자체는
+    // 여전히 존재한다(502가 아닌 연결 거부/503으로 바뀌는 정도).
     new aws.lb.TargetGroupAttachment("hello-prod-tg-attachment", {
         targetGroupArn: targetGroup.arn,
         targetId: springbootInstanceId,
@@ -79,6 +83,7 @@ export function createAlb(
         zoneId,
         name: fqdn,
         type: "A",
+        allowOverwrite: true,
         aliases: [
             {
                 name: alb.dnsName,

--- a/infra/modules/ami.ts
+++ b/infra/modules/ami.ts
@@ -1,12 +1,17 @@
 import * as aws from "@pulumi/aws";
 
 // 항상 최신 Amazon Linux 2023 x86_64 AMI를 조회한다 (AMI ID 하드코딩 금지).
+// "al2023-ami-*-x86_64"는 minimal("al2023-ami-minimal-*")/ecs("al2023-ami-ecs-hvm-*") 변형까지
+// 매치된다 - minimal은 루트 볼륨 기본값이 8GiB가 아니라 2GiB라 docker build 중 디스크가 찰 수
+// 있어 표준 이미지로 필터를 좁힌다. mostRecent:true이므로 새 AMI가 나오면 이 값이 바뀌고,
+// aws.ec2.Instance의 ami는 ForceNew라 인스턴스가 교체된다 - springboot는
+// ignoreChanges로 별도 보호한다 (compute/springbootServer.ts 참고).
 export function getAmazonLinux2023Ami() {
     return aws.ec2.getAmiOutput({
         mostRecent: true,
         owners: ["amazon"],
         filters: [
-            { name: "name", values: ["al2023-ami-*-x86_64"] },
+            { name: "name", values: ["al2023-ami-2023.*-kernel-6.1-x86_64"] },
             { name: "virtualization-type", values: ["hvm"] },
         ],
     });

--- a/infra/modules/ami.ts
+++ b/infra/modules/ami.ts
@@ -1,0 +1,13 @@
+import * as aws from "@pulumi/aws";
+
+// 항상 최신 Amazon Linux 2023 x86_64 AMI를 조회한다 (AMI ID 하드코딩 금지).
+export function getAmazonLinux2023Ami() {
+    return aws.ec2.getAmiOutput({
+        mostRecent: true,
+        owners: ["amazon"],
+        filters: [
+            { name: "name", values: ["al2023-ami-*-x86_64"] },
+            { name: "virtualization-type", values: ["hvm"] },
+        ],
+    });
+}

--- a/infra/modules/codeDeploy.ts
+++ b/infra/modules/codeDeploy.ts
@@ -10,7 +10,10 @@ export interface CodeDeployResult {
 // 기존 리소스라 pulumi import로 흡수한다 (README 참고, GitHub Actions CD 워크플로가 이 정확한
 // 이름을 참조하므로 이름을 바꿀 수도 없음). 기존에는 Auto Scaling Group 기반이었으나 그 ASG는
 // 이미 삭제된 상태라 EC2 태그 필터 기반으로 갱신한다. protect:true로 실수 삭제를 막는다.
-export function createCodeDeploy(serviceRoleArn: aws.iam.Role["arn"]): CodeDeployResult {
+export function createCodeDeploy(
+    serviceRoleArn: aws.iam.Role["arn"],
+    targetGroupName: aws.lb.TargetGroup["name"],
+): CodeDeployResult {
     const application = new aws.codedeploy.Application(
         "hellogsm-prod-codedeploy",
         {
@@ -36,7 +39,17 @@ export function createCodeDeploy(serviceRoleArn: aws.iam.Role["arn"]): CodeDeplo
             ],
             deploymentStyle: {
                 deploymentType: "IN_PLACE",
-                deploymentOption: "WITHOUT_TRAFFIC_CONTROL",
+                // WITHOUT_TRAFFIC_CONTROL이면 배포 중(stop→rm→build→run 수십 초~수 분)에도
+                // ALB가 죽은 타겟에 계속 트래픽을 보내 502가 그대로 노출되고, 그 사이
+                // hello-prod-alb-unhealthy-hosts 알람이 배포마다 발화해 알람 신뢰도가 떨어진다.
+                // WITH_TRAFFIC_CONTROL + loadBalancerInfo로 배포 중 타겟을 등록 해제시킨다
+                // (AWSCodeDeployRole에 RegisterTargets/DeregisterTargets/DescribeTargetHealth가
+                // 이미 포함되어 있어 추가 IAM 변경은 필요 없음). 인스턴스가 1대라 다운타임 자체가
+                // 없어지진 않지만 502가 즉각적인 연결 거부(503) 정도로 바뀐다.
+                deploymentOption: "WITH_TRAFFIC_CONTROL",
+            },
+            loadBalancerInfo: {
+                targetGroupInfos: [{ name: targetGroupName }],
             },
             autoRollbackConfiguration: {
                 enabled: true,

--- a/infra/modules/codeDeploy.ts
+++ b/infra/modules/codeDeploy.ts
@@ -1,0 +1,50 @@
+import * as aws from "@pulumi/aws";
+import { config } from "../config";
+
+export interface CodeDeployResult {
+    application: aws.codedeploy.Application;
+    deploymentGroup: aws.codedeploy.DeploymentGroup;
+}
+
+// hellogsm-prod-codedeploy / api-prod-hellogsm-kr는 2024년부터 실제 배포 이력이 쌓여있는
+// 기존 리소스라 pulumi import로 흡수한다 (README 참고, GitHub Actions CD 워크플로가 이 정확한
+// 이름을 참조하므로 이름을 바꿀 수도 없음). 기존에는 Auto Scaling Group 기반이었으나 그 ASG는
+// 이미 삭제된 상태라 EC2 태그 필터 기반으로 갱신한다. protect:true로 실수 삭제를 막는다.
+export function createCodeDeploy(serviceRoleArn: aws.iam.Role["arn"]): CodeDeployResult {
+    const application = new aws.codedeploy.Application(
+        "hellogsm-prod-codedeploy",
+        {
+            name: "hellogsm-prod-codedeploy",
+            computePlatform: "Server",
+        },
+        { protect: true },
+    );
+
+    const deploymentGroup = new aws.codedeploy.DeploymentGroup(
+        "api-prod-hellogsm-kr",
+        {
+            appName: application.name,
+            deploymentGroupName: "api-prod-hellogsm-kr",
+            serviceRoleArn,
+            deploymentConfigName: "CodeDeployDefault.AllAtOnce",
+            ec2TagSets: [
+                {
+                    ec2TagFilters: [
+                        { key: "Name", type: "KEY_AND_VALUE", value: config.codeDeployTagValue },
+                    ],
+                },
+            ],
+            deploymentStyle: {
+                deploymentType: "IN_PLACE",
+                deploymentOption: "WITHOUT_TRAFFIC_CONTROL",
+            },
+            autoRollbackConfiguration: {
+                enabled: true,
+                events: ["DEPLOYMENT_FAILURE"],
+            },
+        },
+        { protect: true },
+    );
+
+    return { application, deploymentGroup };
+}

--- a/infra/modules/compute/bastionNat.ts
+++ b/infra/modules/compute/bastionNat.ts
@@ -1,0 +1,41 @@
+import * as aws from "@pulumi/aws";
+
+export interface BastionNatResult {
+    instance: aws.ec2.Instance;
+    eip: aws.ec2.Eip;
+}
+
+// 기존에 실제 운영 중인 Bastion+NAT 인스턴스(i-094592acf0b762882, "hello-prod-nat")를
+// pulumi import로 그대로 흡수한다 (README 참고). AMI/인스턴스 타입/키페어는 새로
+// 결정하지 않고 실제 라이브 인스턴스의 현재 값과 정확히 맞춰 replace가 발생하지 않도록 한다.
+export function createBastionNat(
+    publicSubnetId: aws.ec2.Subnet["id"],
+    bastionSgId: aws.ec2.SecurityGroup["id"],
+): BastionNatResult {
+    const instance = new aws.ec2.Instance(
+        "hello-prod-nat",
+        {
+            ami: "ami-0d211b58ff9d9bb61",
+            instanceType: "t4g.micro",
+            subnetId: publicSubnetId,
+            vpcSecurityGroupIds: [bastionSgId],
+            keyName: "hello-prod-bastion",
+            // NAT 겸용 인스턴스는 자신이 발신지/목적지가 아닌 트래픽도 전달해야 하므로 필수
+            sourceDestCheck: false,
+            tags: { Name: "hello-prod-nat" },
+        },
+        { protect: true },
+    );
+
+    const eip = new aws.ec2.Eip(
+        "hello-prod-eip",
+        {
+            instance: instance.id,
+            domain: "vpc",
+            tags: { Name: "hello-prod-eip" },
+        },
+        { protect: true },
+    );
+
+    return { instance, eip };
+}

--- a/infra/modules/compute/redisServer.ts
+++ b/infra/modules/compute/redisServer.ts
@@ -1,4 +1,5 @@
 import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
 import * as path from "path";
 import { config } from "../../config";
@@ -13,18 +14,23 @@ const userData = fs.readFileSync(path.join(__dirname, "../../userdata/redis-ec2.
 export function createRedisServer(
     privateSubnetId: aws.ec2.Subnet["id"],
     redisSgId: aws.ec2.SecurityGroup["id"],
+    opts?: pulumi.ResourceOptions,
 ): RedisServerResult {
     const ami = getAmazonLinux2023Ami();
 
-    const instance = new aws.ec2.Instance("hello-prod-redis", {
-        ami: ami.id,
-        instanceType: config.redisInstanceType,
-        subnetId: privateSubnetId,
-        vpcSecurityGroupIds: [redisSgId],
-        keyName: config.keyPairName,
-        userData,
-        tags: { Name: "hello-prod-redis" },
-    });
+    const instance = new aws.ec2.Instance(
+        "hello-prod-redis",
+        {
+            ami: ami.id,
+            instanceType: config.redisInstanceType,
+            subnetId: privateSubnetId,
+            vpcSecurityGroupIds: [redisSgId],
+            keyName: config.keyPairName,
+            userData,
+            tags: { Name: "hello-prod-redis" },
+        },
+        opts,
+    );
 
     return { instance };
 }

--- a/infra/modules/compute/redisServer.ts
+++ b/infra/modules/compute/redisServer.ts
@@ -1,0 +1,30 @@
+import * as aws from "@pulumi/aws";
+import * as fs from "fs";
+import * as path from "path";
+import { config } from "../../config";
+import { getAmazonLinux2023Ami } from "../ami";
+
+export interface RedisServerResult {
+    instance: aws.ec2.Instance;
+}
+
+const userData = fs.readFileSync(path.join(__dirname, "../../userdata/redis-ec2.sh"), "utf-8");
+
+export function createRedisServer(
+    privateSubnetId: aws.ec2.Subnet["id"],
+    redisSgId: aws.ec2.SecurityGroup["id"],
+): RedisServerResult {
+    const ami = getAmazonLinux2023Ami();
+
+    const instance = new aws.ec2.Instance("hello-prod-redis", {
+        ami: ami.id,
+        instanceType: config.redisInstanceType,
+        subnetId: privateSubnetId,
+        vpcSecurityGroupIds: [redisSgId],
+        keyName: config.keyPairName,
+        userData,
+        tags: { Name: "hello-prod-redis" },
+    });
+
+    return { instance };
+}

--- a/infra/modules/compute/springbootServer.ts
+++ b/infra/modules/compute/springbootServer.ts
@@ -1,4 +1,5 @@
 import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
 import * as path from "path";
 import { config } from "../../config";
@@ -14,20 +15,33 @@ export function createSpringbootServer(
     privateSubnetId: aws.ec2.Subnet["id"],
     springbootSgId: aws.ec2.SecurityGroup["id"],
     instanceProfileName: aws.iam.InstanceProfile["name"],
+    opts?: pulumi.ResourceOptions,
 ): SpringbootServerResult {
     const ami = getAmazonLinux2023Ami();
 
-    const instance = new aws.ec2.Instance("hello-prod-springboot", {
-        ami: ami.id,
-        instanceType: config.springbootInstanceType,
-        subnetId: privateSubnetId,
-        vpcSecurityGroupIds: [springbootSgId],
-        keyName: config.keyPairName,
-        iamInstanceProfile: instanceProfileName,
-        userData,
-        // CodeDeploy 배포 그룹의 EC2 태그 필터(config.codeDeployTagValue)와 반드시 일치해야 한다.
-        tags: { Name: config.codeDeployTagValue },
-    });
+    const instance = new aws.ec2.Instance(
+        "hello-prod-springboot",
+        {
+            ami: ami.id,
+            instanceType: config.springbootInstanceType,
+            subnetId: privateSubnetId,
+            vpcSecurityGroupIds: [springbootSgId],
+            keyName: config.keyPairName,
+            iamInstanceProfile: instanceProfileName,
+            userData,
+            // CodeDeploy 배포 그룹의 EC2 태그 필터(config.codeDeployTagValue)와 반드시 일치해야 한다.
+            tags: { Name: config.codeDeployTagValue },
+        },
+        {
+            ...opts,
+            // ami: mostRecent AMI 조회 결과가 바뀌면 ForceNew라 인스턴스가 교체된다.
+            // userData: 스크립트를 고치면 replace는 아니지만 stop/start가 발생하는데,
+            // scripts/prod-deploy.sh의 docker run에 --restart 정책이 없어 재기동 후
+            // 앱 컨테이너가 스스로 안 올라온다 (CD를 수동으로 다시 돌리기 전까지 전면 장애).
+            // 둘 다 배포 중인 prod 인스턴스에 의도치 않은 영향을 주므로 무시한다.
+            ignoreChanges: ["ami", "userData"],
+        },
+    );
 
     return { instance };
 }

--- a/infra/modules/compute/springbootServer.ts
+++ b/infra/modules/compute/springbootServer.ts
@@ -1,0 +1,33 @@
+import * as aws from "@pulumi/aws";
+import * as fs from "fs";
+import * as path from "path";
+import { config } from "../../config";
+import { getAmazonLinux2023Ami } from "../ami";
+
+export interface SpringbootServerResult {
+    instance: aws.ec2.Instance;
+}
+
+const userData = fs.readFileSync(path.join(__dirname, "../../userdata/springboot-ec2.sh"), "utf-8");
+
+export function createSpringbootServer(
+    privateSubnetId: aws.ec2.Subnet["id"],
+    springbootSgId: aws.ec2.SecurityGroup["id"],
+    instanceProfileName: aws.iam.InstanceProfile["name"],
+): SpringbootServerResult {
+    const ami = getAmazonLinux2023Ami();
+
+    const instance = new aws.ec2.Instance("hello-prod-springboot", {
+        ami: ami.id,
+        instanceType: config.springbootInstanceType,
+        subnetId: privateSubnetId,
+        vpcSecurityGroupIds: [springbootSgId],
+        keyName: config.keyPairName,
+        iamInstanceProfile: instanceProfileName,
+        userData,
+        // CodeDeploy 배포 그룹의 EC2 태그 필터(config.codeDeployTagValue)와 반드시 일치해야 한다.
+        tags: { Name: config.codeDeployTagValue },
+    });
+
+    return { instance };
+}

--- a/infra/modules/database.ts
+++ b/infra/modules/database.ts
@@ -34,7 +34,14 @@ export function createDatabase(
             multiAz: false,
             storageEncrypted: true,
             backupRetentionPeriod: 7,
+            // protect:true를 우회(pulumi state unprotect)해서라도 실수로 삭제될 경우의
+            // 마지막 방어선. deletionProtection은 AWS API 레벨에서 한 번 더 막아준다 -
+            // 삭제하려면 이 값을 먼저 false로 내려야 해서 최소 2단계 확인을 강제한다.
+            deletionProtection: true,
             skipFinalSnapshot: false,
+            // 고정 식별자라 이 이름의 스냅샷이 이미 존재하는 상태에서 삭제하면
+            // DBSnapshotAlreadyExists로 실패한다. 재삭제 전 기존 스냅샷을 지우거나
+            // 이 값을 갱신할 것.
             finalSnapshotIdentifier: "hello-prod-mysql-final-snapshot",
             tags: { Name: "hello-prod-mysql" },
         },

--- a/infra/modules/database.ts
+++ b/infra/modules/database.ts
@@ -1,0 +1,45 @@
+import * as aws from "@pulumi/aws";
+import { config } from "../config";
+
+export interface DatabaseResult {
+    subnetGroup: aws.rds.SubnetGroup;
+    instance: aws.rds.Instance;
+}
+
+export function createDatabase(
+    prodPrivateSubnet2aId: aws.ec2.Subnet["id"],
+    privateSubnet2bId: aws.ec2.Subnet["id"],
+    rdsSgId: aws.ec2.SecurityGroup["id"],
+): DatabaseResult {
+    const subnetGroup = new aws.rds.SubnetGroup("hello-prod-rds-subnet-group", {
+        name: "hello-prod-rds-subnet-group",
+        subnetIds: [prodPrivateSubnet2aId, privateSubnet2bId],
+        tags: { Name: "hello-prod-rds-subnet-group" },
+    });
+
+    const instance = new aws.rds.Instance(
+        "hello-prod-mysql",
+        {
+            identifier: "hello-prod-mysql",
+            engine: "mysql",
+            engineVersion: config.dbEngineVersion,
+            instanceClass: config.dbInstanceClass,
+            allocatedStorage: config.dbAllocatedStorage,
+            dbName: config.dbName,
+            username: config.dbUsername,
+            password: config.dbPassword,
+            dbSubnetGroupName: subnetGroup.name,
+            vpcSecurityGroupIds: [rdsSgId],
+            publiclyAccessible: false,
+            multiAz: false,
+            storageEncrypted: true,
+            backupRetentionPeriod: 7,
+            skipFinalSnapshot: false,
+            finalSnapshotIdentifier: "hello-prod-mysql-final-snapshot",
+            tags: { Name: "hello-prod-mysql" },
+        },
+        { protect: true },
+    );
+
+    return { subnetGroup, instance };
+}

--- a/infra/modules/dnsCert.ts
+++ b/infra/modules/dnsCert.ts
@@ -1,0 +1,37 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import { config, fqdn } from "../config";
+
+export interface DnsCertResult {
+    zone: pulumi.Output<aws.route53.GetZoneResult>;
+    certificate: aws.acm.Certificate;
+    certificateValidation: aws.acm.CertificateValidation;
+}
+
+// hellogsm.kr Hosted Zone은 AWS에 이미 존재하므로 데이터 소스로만 조회하고,
+// Pulumi로 새로 생성하지 않는다.
+export function createDnsAndCertificate(): DnsCertResult {
+    const zone = aws.route53.getZoneOutput({ name: config.domainName });
+
+    const certificate = new aws.acm.Certificate("api-prod-cert", {
+        domainName: fqdn,
+        validationMethod: "DNS",
+        tags: { Name: fqdn },
+    });
+
+    const validationRecord = new aws.route53.Record("api-prod-cert-validation", {
+        zoneId: zone.zoneId,
+        name: certificate.domainValidationOptions[0].resourceRecordName,
+        type: certificate.domainValidationOptions[0].resourceRecordType,
+        records: [certificate.domainValidationOptions[0].resourceRecordValue],
+        ttl: 60,
+        allowOverwrite: true,
+    });
+
+    const certificateValidation = new aws.acm.CertificateValidation("api-prod-cert-validation", {
+        certificateArn: certificate.arn,
+        validationRecordFqdns: [validationRecord.fqdn],
+    });
+
+    return { zone, certificate, certificateValidation };
+}

--- a/infra/modules/iam.ts
+++ b/infra/modules/iam.ts
@@ -66,8 +66,8 @@ export function createIam(
                     Sid: "SnsPublish",
                     Effect: "Allow",
                     Action: ["sns:Publish"],
-                    // 앱이 사용하는 정확한 SNS 토픽이 코드베이스상 특정되지 않아 우선 광범위 허용.
-                    // 실제 사용 토픽이 확인되면 Resource를 해당 ARN으로 축소할 것.
+                    // SnsSmsTemplate로 전화번호 지정 직접 SMS 발송(SendSmsServiceImpl)만 사용 -
+                    // Topic ARN이 존재하지 않는 발행 방식이라 리소스 레벨로 좁힐 수 없음(AWS 제약).
                     Resource: "*",
                 },
             ],

--- a/infra/modules/iam.ts
+++ b/infra/modules/iam.ts
@@ -1,0 +1,185 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import { config } from "../config";
+
+export interface IamResult {
+    springbootInstanceProfile: aws.iam.InstanceProfile;
+    codeDeployServiceRole: aws.iam.Role;
+    githubActionsDeployRole: aws.iam.Role;
+}
+
+const CODEDEPLOY_APPLICATION_NAME = "hellogsm-prod-codedeploy";
+const CODEDEPLOY_DEPLOYMENT_GROUP_NAME = "api-prod-hellogsm-kr";
+const LOG_GROUP_NAME = "hellogsm-prod-log";
+
+export function createIam(
+    deploymentBucketArn: pulumi.Input<string>,
+    appAssetsBucketArn: pulumi.Input<string>,
+): IamResult {
+    const identity = aws.getCallerIdentityOutput({});
+    const accountId = identity.accountId;
+    const region = config.region;
+
+    const logGroupArn = pulumi.interpolate`arn:aws:logs:${region}:${accountId}:log-group:${LOG_GROUP_NAME}:*`;
+    const codeDeployApplicationArn = pulumi.interpolate`arn:aws:codedeploy:${region}:${accountId}:application:${CODEDEPLOY_APPLICATION_NAME}`;
+    const codeDeployDeploymentGroupArn = pulumi.interpolate`arn:aws:codedeploy:${region}:${accountId}:deploymentgroup:${CODEDEPLOY_APPLICATION_NAME}/${CODEDEPLOY_DEPLOYMENT_GROUP_NAME}`;
+
+    // ---- EC2 (Spring Boot) instance role/profile ----
+    const springbootEc2Role = new aws.iam.Role("hello-prod-springboot-ec2-role", {
+        name: "hello-prod-springboot-ec2-role",
+        assumeRolePolicy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+                {
+                    Effect: "Allow",
+                    Principal: { Service: "ec2.amazonaws.com" },
+                    Action: "sts:AssumeRole",
+                },
+            ],
+        }),
+    });
+
+    new aws.iam.RolePolicy("hello-prod-springboot-ec2-policy", {
+        role: springbootEc2Role.id,
+        policy: pulumi.jsonStringify({
+            Version: "2012-10-17",
+            Statement: [
+                {
+                    Sid: "DeploymentBucketRead",
+                    Effect: "Allow",
+                    Action: ["s3:GetObject", "s3:ListBucket"],
+                    Resource: [deploymentBucketArn, pulumi.interpolate`${deploymentBucketArn}/*`],
+                },
+                {
+                    Sid: "AppAssetsBucketReadWrite",
+                    Effect: "Allow",
+                    Action: ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+                    Resource: [appAssetsBucketArn, pulumi.interpolate`${appAssetsBucketArn}/*`],
+                },
+                {
+                    Sid: "CloudWatchLogs",
+                    Effect: "Allow",
+                    Action: ["logs:CreateLogStream", "logs:PutLogEvents", "logs:DescribeLogStreams"],
+                    Resource: logGroupArn,
+                },
+                {
+                    Sid: "SnsPublish",
+                    Effect: "Allow",
+                    Action: ["sns:Publish"],
+                    // 앱이 사용하는 정확한 SNS 토픽이 코드베이스상 특정되지 않아 우선 광범위 허용.
+                    // 실제 사용 토픽이 확인되면 Resource를 해당 ARN으로 축소할 것.
+                    Resource: "*",
+                },
+            ],
+        }),
+    });
+
+    // CodeDeploy agent가 배포 상태를 보고하기 위해 필요한 최소 권한(AWS 관리형 정책 없음 - 인라인으로 부여)
+    new aws.iam.RolePolicy("hello-prod-springboot-codedeploy-agent-policy", {
+        role: springbootEc2Role.id,
+        policy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+                {
+                    Sid: "CodeDeployAgent",
+                    Effect: "Allow",
+                    Action: [
+                        "codedeploy:PollHostCommand",
+                        "codedeploy:PutHostCommandComplete",
+                        "codedeploy:GetDeployment",
+                        "codedeploy:GetApplicationRevision",
+                    ],
+                    Resource: "*",
+                },
+            ],
+        }),
+    });
+
+    const springbootInstanceProfile = new aws.iam.InstanceProfile("hello-prod-springboot-instance-profile", {
+        role: springbootEc2Role.name,
+    });
+
+    // ---- CodeDeploy service role ----
+    const codeDeployServiceRole = new aws.iam.Role("hello-prod-codedeploy-service-role", {
+        name: "hello-prod-codedeploy-service-role",
+        assumeRolePolicy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+                {
+                    Effect: "Allow",
+                    Principal: { Service: "codedeploy.amazonaws.com" },
+                    Action: "sts:AssumeRole",
+                },
+            ],
+        }),
+    });
+
+    new aws.iam.RolePolicyAttachment("hello-prod-codedeploy-service-role-attach", {
+        role: codeDeployServiceRole.name,
+        policyArn: "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole",
+    });
+
+    // ---- GitHub OIDC provider + deploy role ----
+    const githubOidcProvider = new aws.iam.OpenIdConnectProvider("github-actions-oidc", {
+        url: "https://token.actions.githubusercontent.com",
+        clientIdLists: ["sts.amazonaws.com"],
+        // GitHub Actions OIDC 루트 CA 지문 (2023년 기준 공개된 값)
+        thumbprintLists: ["6938fd4d98bab03faadb97b34396831e3780aea1"],
+    });
+
+    const githubActionsDeployRole = new aws.iam.Role("hello-prod-github-actions-deploy-role", {
+        name: "hello-prod-github-actions-deploy-role",
+        assumeRolePolicy: pulumi.jsonStringify({
+            Version: "2012-10-17",
+            Statement: [
+                {
+                    Effect: "Allow",
+                    Principal: { Federated: githubOidcProvider.arn },
+                    Action: "sts:AssumeRoleWithWebIdentity",
+                    Condition: {
+                        StringEquals: {
+                            "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                        },
+                        StringLike: {
+                            "token.actions.githubusercontent.com:sub": `repo:${config.githubOrg}/${config.githubRepo}:ref:refs/heads/main`,
+                        },
+                    },
+                },
+            ],
+        }),
+    });
+
+    new aws.iam.RolePolicy("hello-prod-github-actions-deploy-policy", {
+        role: githubActionsDeployRole.id,
+        policy: pulumi.jsonStringify({
+            Version: "2012-10-17",
+            Statement: [
+                {
+                    Sid: "UploadDeploymentArtifact",
+                    Effect: "Allow",
+                    Action: ["s3:PutObject"],
+                    Resource: pulumi.interpolate`${deploymentBucketArn}/prod/*`,
+                },
+                {
+                    Sid: "TriggerCodeDeploy",
+                    Effect: "Allow",
+                    Action: [
+                        "codedeploy:CreateDeployment",
+                        "codedeploy:GetDeployment",
+                        "codedeploy:GetApplication",
+                        "codedeploy:RegisterApplicationRevision",
+                    ],
+                    Resource: [codeDeployApplicationArn, codeDeployDeploymentGroupArn],
+                },
+                {
+                    Sid: "ReadDeploymentConfig",
+                    Effect: "Allow",
+                    Action: ["codedeploy:GetDeploymentConfig"],
+                    Resource: "*",
+                },
+            ],
+        }),
+    });
+
+    return { springbootInstanceProfile, codeDeployServiceRole, githubActionsDeployRole };
+}

--- a/infra/modules/iam.ts
+++ b/infra/modules/iam.ts
@@ -20,7 +20,10 @@ export function createIam(
     const accountId = identity.accountId;
     const region = config.region;
 
-    const logGroupArn = pulumi.interpolate`arn:aws:logs:${region}:${accountId}:log-group:${LOG_GROUP_NAME}:*`;
+    // CloudWatchAppender가 기동 시 무조건 CreateLogGroup을 호출한다(그룹이 이미 있어도).
+    // CreateLogGroup은 ":*" 없는 로그그룹 ARN 형태로 평가될 수 있어 두 형태 모두 허용한다.
+    const logGroupArnBase = pulumi.interpolate`arn:aws:logs:${region}:${accountId}:log-group:${LOG_GROUP_NAME}`;
+    const logGroupArn = pulumi.interpolate`${logGroupArnBase}:*`;
     const codeDeployApplicationArn = pulumi.interpolate`arn:aws:codedeploy:${region}:${accountId}:application:${CODEDEPLOY_APPLICATION_NAME}`;
     const codeDeployDeploymentGroupArn = pulumi.interpolate`arn:aws:codedeploy:${region}:${accountId}:deploymentgroup:${CODEDEPLOY_APPLICATION_NAME}/${CODEDEPLOY_DEPLOYMENT_GROUP_NAME}`;
 
@@ -59,8 +62,13 @@ export function createIam(
                 {
                     Sid: "CloudWatchLogs",
                     Effect: "Allow",
-                    Action: ["logs:CreateLogStream", "logs:PutLogEvents", "logs:DescribeLogStreams"],
-                    Resource: logGroupArn,
+                    Action: [
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents",
+                        "logs:DescribeLogStreams",
+                    ],
+                    Resource: [logGroupArnBase, logGroupArn],
                 },
                 {
                     Sid: "SnsPublish",
@@ -74,22 +82,20 @@ export function createIam(
         }),
     });
 
-    // CodeDeploy agent가 배포 상태를 보고하기 위해 필요한 최소 권한(AWS 관리형 정책 없음 - 인라인으로 부여)
+    // CodeDeploy agent 설치 스크립트(userdata/springboot-ec2.sh)가 리전별 AWS 관리 버킷에서
+    // 설치 파일을 wget으로 받아온다. "codedeploy:PollHostCommand" 등은 실제로 존재하지 않는
+    // IAM 액션(agent의 host command API는 codedeploy-commands-secure: 네임스페이스)이라 삭제하고,
+    // 대신 AWS 공식 가이드가 요구하는 이 S3 읽기 권한을 부여한다.
     new aws.iam.RolePolicy("hello-prod-springboot-codedeploy-agent-policy", {
         role: springbootEc2Role.id,
         policy: JSON.stringify({
             Version: "2012-10-17",
             Statement: [
                 {
-                    Sid: "CodeDeployAgent",
+                    Sid: "CodeDeployAgentInstaller",
                     Effect: "Allow",
-                    Action: [
-                        "codedeploy:PollHostCommand",
-                        "codedeploy:PutHostCommandComplete",
-                        "codedeploy:GetDeployment",
-                        "codedeploy:GetApplicationRevision",
-                    ],
-                    Resource: "*",
+                    Action: ["s3:GetObject"],
+                    Resource: "arn:aws:s3:::aws-codedeploy-ap-northeast-2/*",
                 },
             ],
         }),
@@ -123,7 +129,9 @@ export function createIam(
     const githubOidcProvider = new aws.iam.OpenIdConnectProvider("github-actions-oidc", {
         url: "https://token.actions.githubusercontent.com",
         clientIdLists: ["sts.amazonaws.com"],
-        // GitHub Actions OIDC 루트 CA 지문 (2023년 기준 공개된 값)
+        // aws.iam.OpenIdConnectProvider는 thumbprintLists를 필수로 요구하지만, 2024-12-12부터
+        // AWS는 token.actions.githubusercontent.com 같은 신뢰된 IdP에 대해 이 값을 실제로는
+        // 무시한다. 갱신이 필요한 값이 아니므로 이후 값을 최신화할 필요 없음.
         thumbprintLists: ["6938fd4d98bab03faadb97b34396831e3780aea1"],
     });
 

--- a/infra/modules/monitoring.ts
+++ b/infra/modules/monitoring.ts
@@ -1,0 +1,101 @@
+import * as aws from "@pulumi/aws";
+import { config } from "../config";
+
+export interface MonitoringResult {
+    logGroup: aws.cloudwatch.LogGroup;
+    alertsTopic: aws.sns.Topic;
+}
+
+// Discord 웹훅 연동은 이번 스코프 밖 - SNS Topic 생성까지만 담당한다.
+export function createMonitoring(
+    targetGroupArnSuffix: aws.lb.TargetGroup["arnSuffix"],
+    albArnSuffix: aws.lb.LoadBalancer["arnSuffix"],
+    springbootInstanceId: aws.ec2.Instance["id"],
+    redisInstanceId: aws.ec2.Instance["id"],
+): MonitoringResult {
+    // 2024년부터 실제 운영 로그(약 1GB)가 쌓여있는 기존 로그 그룹을 pulumi import로 흡수한다
+    // (README 참고). protect:true로 실수 삭제를 막는다 - 삭제 시 로그가 전부 유실된다.
+    const logGroup = new aws.cloudwatch.LogGroup(
+        "hellogsm-prod-log",
+        {
+            name: "hellogsm-prod-log",
+            // 0 = 만료 없음 (logback-spring.xml의 retentionTimeDays=0과 정합)
+            retentionInDays: config.logRetentionDays,
+            tags: { Name: "hellogsm-prod-log" },
+        },
+        { protect: true },
+    );
+
+    const alertsTopic = new aws.sns.Topic("hello-prod-alerts", {
+        name: "hello-prod-alerts",
+    });
+
+    if (config.snsAlarmEmail) {
+        new aws.sns.TopicSubscription("hello-prod-alerts-email", {
+            topic: alertsTopic.arn,
+            protocol: "email",
+            endpoint: config.snsAlarmEmail,
+        });
+    }
+
+    new aws.cloudwatch.MetricAlarm("hello-prod-alb-unhealthy-hosts", {
+        name: "hello-prod-alb-unhealthy-hosts",
+        namespace: "AWS/ApplicationELB",
+        metricName: "UnHealthyHostCount",
+        dimensions: { TargetGroup: targetGroupArnSuffix, LoadBalancer: albArnSuffix },
+        statistic: "Maximum",
+        period: 60,
+        evaluationPeriods: 2,
+        threshold: 1,
+        comparisonOperator: "GreaterThanOrEqualToThreshold",
+        treatMissingData: "breaching",
+        alarmActions: [alertsTopic.arn],
+        okActions: [alertsTopic.arn],
+    });
+
+    new aws.cloudwatch.MetricAlarm("hello-prod-alb-5xx", {
+        name: "hello-prod-alb-5xx",
+        namespace: "AWS/ApplicationELB",
+        metricName: "HTTPCode_Target_5XX_Count",
+        dimensions: { TargetGroup: targetGroupArnSuffix, LoadBalancer: albArnSuffix },
+        statistic: "Sum",
+        period: 60,
+        evaluationPeriods: 1,
+        threshold: 5,
+        comparisonOperator: "GreaterThanOrEqualToThreshold",
+        treatMissingData: "notBreaching",
+        alarmActions: [alertsTopic.arn],
+    });
+
+    new aws.cloudwatch.MetricAlarm("hello-prod-springboot-status-check-failed", {
+        name: "hello-prod-springboot-status-check-failed",
+        namespace: "AWS/EC2",
+        metricName: "StatusCheckFailed",
+        dimensions: { InstanceId: springbootInstanceId },
+        statistic: "Maximum",
+        period: 60,
+        evaluationPeriods: 2,
+        threshold: 1,
+        comparisonOperator: "GreaterThanOrEqualToThreshold",
+        treatMissingData: "breaching",
+        alarmActions: [alertsTopic.arn],
+        okActions: [alertsTopic.arn],
+    });
+
+    new aws.cloudwatch.MetricAlarm("hello-prod-redis-status-check-failed", {
+        name: "hello-prod-redis-status-check-failed",
+        namespace: "AWS/EC2",
+        metricName: "StatusCheckFailed",
+        dimensions: { InstanceId: redisInstanceId },
+        statistic: "Maximum",
+        period: 60,
+        evaluationPeriods: 2,
+        threshold: 1,
+        comparisonOperator: "GreaterThanOrEqualToThreshold",
+        treatMissingData: "breaching",
+        alarmActions: [alertsTopic.arn],
+        okActions: [alertsTopic.arn],
+    });
+
+    return { logGroup, alertsTopic };
+}

--- a/infra/modules/network.ts
+++ b/infra/modules/network.ts
@@ -1,0 +1,166 @@
+import * as aws from "@pulumi/aws";
+
+export interface NetworkResult {
+    vpc: aws.ec2.Vpc;
+    igw: aws.ec2.InternetGateway;
+    prodPublicSubnet2a: aws.ec2.Subnet;
+    publicSubnet2b: aws.ec2.Subnet;
+    prodPrivateSubnet2a: aws.ec2.Subnet;
+    privateSubnet2b: aws.ec2.Subnet;
+    prodPublicRouteTable2a: aws.ec2.RouteTable;
+    publicRouteTable2b: aws.ec2.RouteTable;
+    prodPrivateRouteTable2a: aws.ec2.RouteTable;
+    prodPrivateRouteTable2b: aws.ec2.RouteTable;
+}
+
+// 이 모듈이 다루는 VPC/서브넷/IGW/라우트테이블은 전부 기존에 실제로 존재하는(2024년부터 운영되어온)
+// 네트워크를 그대로 가져온 것이다 (pulumi import로 state에 흡수, README 참고).
+// protect:true로 걸어 실수로 삭제되는 일이 없도록 한다 - hello-pub-rtb는 stage 환경과 공유되는
+// 라우트테이블이라 특히 주의가 필요하다.
+export function createNetwork(): NetworkResult {
+    const vpc = new aws.ec2.Vpc(
+        "hello-vpc",
+        {
+            cidrBlock: "172.16.0.0/24",
+            enableDnsSupport: true,
+            enableDnsHostnames: true,
+            tags: { Name: "hello-vpc" },
+        },
+        { protect: true },
+    );
+
+    const igw = new aws.ec2.InternetGateway(
+        "hellogsm-igw",
+        {
+            vpcId: vpc.id,
+            tags: { Name: "hellogsm-igw" },
+        },
+        { protect: true },
+    );
+
+    const prodPublicSubnet2a = new aws.ec2.Subnet(
+        "hello-prod-public-2a",
+        {
+            vpcId: vpc.id,
+            cidrBlock: "172.16.0.0/27",
+            availabilityZone: "ap-northeast-2a",
+            // 실제 기존 서브넷 설정(false)을 그대로 유지 - NAT 인스턴스는 EIP를 별도로 붙여 쓰므로 무관
+            mapPublicIpOnLaunch: false,
+            tags: { Name: "hello-prod-public-2a" },
+        },
+        { protect: true },
+    );
+
+    const publicSubnet2b = new aws.ec2.Subnet(
+        "hello-public-subnet-2b",
+        {
+            vpcId: vpc.id,
+            cidrBlock: "172.16.0.32/27",
+            availabilityZone: "ap-northeast-2b",
+            // 실제 기존 서브넷 설정(false)을 그대로 유지
+            mapPublicIpOnLaunch: false,
+            tags: { Name: "hello-public-subnet-2b" },
+        },
+        { protect: true },
+    );
+
+    const prodPrivateSubnet2a = new aws.ec2.Subnet(
+        "hello-prod-private-2a",
+        {
+            vpcId: vpc.id,
+            cidrBlock: "172.16.0.64/27",
+            availabilityZone: "ap-northeast-2a",
+            mapPublicIpOnLaunch: false,
+            tags: { Name: "hello-prod-private-2a" },
+        },
+        { protect: true },
+    );
+
+    const privateSubnet2b = new aws.ec2.Subnet(
+        "hello-private-subnet-2b",
+        {
+            vpcId: vpc.id,
+            cidrBlock: "172.16.0.96/27",
+            availabilityZone: "ap-northeast-2b",
+            mapPublicIpOnLaunch: false,
+            tags: { Name: "hello-private-subnet-2b" },
+        },
+        { protect: true },
+    );
+
+    // 2a 퍼블릭 전용 라우트테이블
+    const prodPublicRouteTable2a = new aws.ec2.RouteTable(
+        "hello-prod-pub-rtb-a",
+        {
+            vpcId: vpc.id,
+            routes: [{ cidrBlock: "0.0.0.0/0", gatewayId: igw.id }],
+            tags: { Name: "hello-prod-pub-rtb-a" },
+        },
+        { protect: true },
+    );
+
+    new aws.ec2.RouteTableAssociation("hello-prod-public-2a-assoc", {
+        subnetId: prodPublicSubnet2a.id,
+        routeTableId: prodPublicRouteTable2a.id,
+    });
+
+    // 2b 퍼블릭 라우트테이블 - hello-dev-public-2a(stage NAT)와 공유되므로 절대 삭제 금지
+    const publicRouteTable2b = new aws.ec2.RouteTable(
+        "hello-pub-rtb",
+        {
+            vpcId: vpc.id,
+            routes: [{ cidrBlock: "0.0.0.0/0", gatewayId: igw.id }],
+            tags: { Name: "hello-pub-rtb" },
+        },
+        { protect: true },
+    );
+
+    new aws.ec2.RouteTableAssociation("hello-public-subnet-2b-assoc", {
+        subnetId: publicSubnet2b.id,
+        routeTableId: publicRouteTable2b.id,
+    });
+
+    // 프라이빗 라우트테이블 2개 모두 인터넷 라우트(0.0.0.0/0)는 NAT 인스턴스 ENI로 향한다.
+    // NAT 인스턴스는 index.ts에서 생성/조합되므로 여기서는 로컬 라우트만 두고,
+    // 인터넷 라우트는 index.ts에서 별도 aws.ec2.Route로 추가한다.
+    const prodPrivateRouteTable2a = new aws.ec2.RouteTable(
+        "hello-prod-priv-rtb-a",
+        {
+            vpcId: vpc.id,
+            tags: { Name: "hello-prod-priv-rtb-a" },
+        },
+        { protect: true },
+    );
+
+    new aws.ec2.RouteTableAssociation("hello-prod-private-2a-assoc", {
+        subnetId: prodPrivateSubnet2a.id,
+        routeTableId: prodPrivateRouteTable2a.id,
+    });
+
+    const prodPrivateRouteTable2b = new aws.ec2.RouteTable(
+        "hello-prod-priv-rtb-b",
+        {
+            vpcId: vpc.id,
+            tags: { Name: "hello-prod-priv-rtb-b" },
+        },
+        { protect: true },
+    );
+
+    new aws.ec2.RouteTableAssociation("hello-private-subnet-2b-assoc", {
+        subnetId: privateSubnet2b.id,
+        routeTableId: prodPrivateRouteTable2b.id,
+    });
+
+    return {
+        vpc,
+        igw,
+        prodPublicSubnet2a,
+        publicSubnet2b,
+        prodPrivateSubnet2a,
+        privateSubnet2b,
+        prodPublicRouteTable2a,
+        publicRouteTable2b,
+        prodPrivateRouteTable2a,
+        prodPrivateRouteTable2b,
+    };
+}

--- a/infra/modules/network.ts
+++ b/infra/modules/network.ts
@@ -88,37 +88,69 @@ export function createNetwork(): NetworkResult {
         { protect: true },
     );
 
+    // 4개 라우트테이블 모두 인라인 routes를 쓰지 않는다. aws.ec2.RouteTable.routes를
+    // 명시하면 그 목록이 authoritative가 되어, 코드에 없는 라우트는 다음 pulumi up 때
+    // 삭제된다. hello-pub-rtb는 stage(hello-dev-public-2a)와 공유되는 테이블이라 stage
+    // 쪽에서 라우트를 추가/변경해도 prod 스택이 그걸 모른 채 조용히 지우면 안 되므로,
+    // 모든 인터넷 라우트를 별도 aws.ec2.Route 리소스로 선언해 non-authoritative하게 관리한다.
+
     // 2a 퍼블릭 전용 라우트테이블
     const prodPublicRouteTable2a = new aws.ec2.RouteTable(
         "hello-prod-pub-rtb-a",
         {
             vpcId: vpc.id,
-            routes: [{ cidrBlock: "0.0.0.0/0", gatewayId: igw.id }],
             tags: { Name: "hello-prod-pub-rtb-a" },
         },
         { protect: true },
     );
 
-    new aws.ec2.RouteTableAssociation("hello-prod-public-2a-assoc", {
-        subnetId: prodPublicSubnet2a.id,
-        routeTableId: prodPublicRouteTable2a.id,
-    });
+    new aws.ec2.Route(
+        "hello-prod-pub-rtb-a-igw-route",
+        {
+            routeTableId: prodPublicRouteTable2a.id,
+            destinationCidrBlock: "0.0.0.0/0",
+            gatewayId: igw.id,
+        },
+        { protect: true },
+    );
+
+    new aws.ec2.RouteTableAssociation(
+        "hello-prod-public-2a-assoc",
+        {
+            subnetId: prodPublicSubnet2a.id,
+            routeTableId: prodPublicRouteTable2a.id,
+        },
+        { protect: true },
+    );
 
     // 2b 퍼블릭 라우트테이블 - hello-dev-public-2a(stage NAT)와 공유되므로 절대 삭제 금지
     const publicRouteTable2b = new aws.ec2.RouteTable(
         "hello-pub-rtb",
         {
             vpcId: vpc.id,
-            routes: [{ cidrBlock: "0.0.0.0/0", gatewayId: igw.id }],
             tags: { Name: "hello-pub-rtb" },
         },
         { protect: true },
     );
 
-    new aws.ec2.RouteTableAssociation("hello-public-subnet-2b-assoc", {
-        subnetId: publicSubnet2b.id,
-        routeTableId: publicRouteTable2b.id,
-    });
+    new aws.ec2.Route(
+        "hello-pub-rtb-igw-route",
+        {
+            routeTableId: publicRouteTable2b.id,
+            destinationCidrBlock: "0.0.0.0/0",
+            gatewayId: igw.id,
+        },
+        { protect: true },
+    );
+
+    new aws.ec2.RouteTableAssociation(
+        "hello-public-subnet-2b-assoc",
+        {
+            subnetId: publicSubnet2b.id,
+            routeTableId: publicRouteTable2b.id,
+        },
+        { protect: true },
+    );
 
     // 프라이빗 라우트테이블 2개 모두 인터넷 라우트(0.0.0.0/0)는 NAT 인스턴스 ENI로 향한다.
     // NAT 인스턴스는 index.ts에서 생성/조합되므로 여기서는 로컬 라우트만 두고,
@@ -132,10 +164,14 @@ export function createNetwork(): NetworkResult {
         { protect: true },
     );
 
-    new aws.ec2.RouteTableAssociation("hello-prod-private-2a-assoc", {
-        subnetId: prodPrivateSubnet2a.id,
-        routeTableId: prodPrivateRouteTable2a.id,
-    });
+    new aws.ec2.RouteTableAssociation(
+        "hello-prod-private-2a-assoc",
+        {
+            subnetId: prodPrivateSubnet2a.id,
+            routeTableId: prodPrivateRouteTable2a.id,
+        },
+        { protect: true },
+    );
 
     const prodPrivateRouteTable2b = new aws.ec2.RouteTable(
         "hello-prod-priv-rtb-b",
@@ -146,10 +182,14 @@ export function createNetwork(): NetworkResult {
         { protect: true },
     );
 
-    new aws.ec2.RouteTableAssociation("hello-private-subnet-2b-assoc", {
-        subnetId: privateSubnet2b.id,
-        routeTableId: prodPrivateRouteTable2b.id,
-    });
+    new aws.ec2.RouteTableAssociation(
+        "hello-private-subnet-2b-assoc",
+        {
+            subnetId: privateSubnet2b.id,
+            routeTableId: prodPrivateRouteTable2b.id,
+        },
+        { protect: true },
+    );
 
     return {
         vpc,

--- a/infra/modules/s3.ts
+++ b/infra/modules/s3.ts
@@ -1,0 +1,34 @@
+import * as aws from "@pulumi/aws";
+import { config } from "../config";
+
+export interface S3Result {
+    deploymentBucket: aws.s3.BucketV2;
+    appAssetsBucket: aws.s3.BucketV2;
+}
+
+// 기존에 남아있는 버킷이 있을 수 있으므로 protect:true로 실수 삭제를 방지한다.
+// 버킷이 이미 AWS에 존재하면 `pulumi up` 전에
+//   pulumi import aws:s3/bucketV2:BucketV2 deploymentBucket <bucket-name>
+//   pulumi import aws:s3/bucketV2:BucketV2 appAssetsBucket <bucket-name>
+// 로 state에 흡수한다 (infra/README.md 참고). 존재하지 않으면 그대로 pulumi up이 신규 생성한다.
+export function createS3Buckets(): S3Result {
+    const deploymentBucket = new aws.s3.BucketV2(
+        "deploymentBucket",
+        {
+            bucket: config.deploymentBucketName,
+            tags: { Name: config.deploymentBucketName },
+        },
+        { protect: true },
+    );
+
+    const appAssetsBucket = new aws.s3.BucketV2(
+        "appAssetsBucket",
+        {
+            bucket: config.appAssetsBucketName,
+            tags: { Name: config.appAssetsBucketName },
+        },
+        { protect: true },
+    );
+
+    return { deploymentBucket, appAssetsBucket };
+}

--- a/infra/modules/securityGroups.ts
+++ b/infra/modules/securityGroups.ts
@@ -64,7 +64,10 @@ export function createSecurityGroups(vpcId: aws.ec2.Vpc["id"]): SecurityGroupsRe
         tags: { Name: "hello-prod-rds-sg" },
     });
 
-    // 순환 참조(springboot <-> redis/rds) 회피를 위해 SG 룰은 별도 리소스로 분리 생성
+    // 순환 참조(springboot <-> redis/rds) 회피를 위해 SG 룰은 별도 리소스로 분리 생성.
+    // 주의: springbootSg/redisSg/rdsSg는 인라인 ingress를 쓰지 않는다 - AWS 프로바이더는
+    // 한 SG에 인라인 룰과 독립 SecurityGroupRule 리소스를 섞어 쓰는 걸 금지하며, 섞이면
+    // 아래 독립 룰들이 조용히 덮어써진다. 이 SG들에는 절대 인라인 ingress를 추가하지 말 것.
     new aws.ec2.SecurityGroupRule("springboot-from-alb-8080", {
         type: "ingress",
         securityGroupId: springbootSg.id,

--- a/infra/modules/securityGroups.ts
+++ b/infra/modules/securityGroups.ts
@@ -1,0 +1,110 @@
+import * as aws from "@pulumi/aws";
+
+export interface SecurityGroupsResult {
+    albSg: aws.ec2.SecurityGroup;
+    bastionSg: aws.ec2.SecurityGroup;
+    springbootSg: aws.ec2.SecurityGroup;
+    redisSg: aws.ec2.SecurityGroup;
+    rdsSg: aws.ec2.SecurityGroup;
+}
+
+export function createSecurityGroups(vpcId: aws.ec2.Vpc["id"]): SecurityGroupsResult {
+    const albSg = new aws.ec2.SecurityGroup("hello-prod-alb-sg", {
+        vpcId,
+        description: "ALB - allow inbound HTTP/HTTPS from internet",
+        ingress: [
+            { protocol: "tcp", fromPort: 80, toPort: 80, cidrBlocks: ["0.0.0.0/0"] },
+            { protocol: "tcp", fromPort: 443, toPort: 443, cidrBlocks: ["0.0.0.0/0"] },
+        ],
+        egress: [{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] }],
+        tags: { Name: "hello-prod-alb-sg" },
+    });
+
+    // 기존에 실제 운영 중인 NAT 인스턴스가 붙어 있는 보안그룹을 그대로 import한다
+    // (pulumi import, README 참고). 현재 룰이 0.0.0.0/0 전체 허용으로 다소 느슨하지만,
+    // "있는 그대로 흡수"가 목표이므로 임의로 좁히지 않고 실제 상태를 그대로 코드에 반영한다.
+    const bastionSg = new aws.ec2.SecurityGroup(
+        "hellogsm-nat-sg",
+        {
+            vpcId,
+            // description은 AWS에서 변경 시 리소스 교체(delete+recreate)를 유발하는 불변 필드라
+            // 실제 값("hellogsm-nat-sg")과 정확히 동일하게 맞춘다.
+            description: "hellogsm-nat-sg",
+            ingress: [
+                { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0", "172.16.0.0/24"] },
+            ],
+            egress: [{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] }],
+            tags: { Name: "hellogsm-nat-sg" },
+        },
+        { protect: true },
+    );
+
+    const springbootSg = new aws.ec2.SecurityGroup("hello-prod-springboot-sg", {
+        vpcId,
+        description: "Spring Boot EC2 - allow 8080 from ALB, SSH from Bastion",
+        egress: [{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] }],
+        tags: { Name: "hello-prod-springboot-sg" },
+    });
+
+    const redisSg = new aws.ec2.SecurityGroup("hello-prod-redis-sg", {
+        vpcId,
+        description: "Redis EC2 - allow 6379 from Spring Boot, SSH from Bastion",
+        egress: [{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] }],
+        tags: { Name: "hello-prod-redis-sg" },
+    });
+
+    const rdsSg = new aws.ec2.SecurityGroup("hello-prod-rds-sg", {
+        vpcId,
+        description: "RDS MySQL - allow 3306 from Spring Boot",
+        egress: [{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] }],
+        tags: { Name: "hello-prod-rds-sg" },
+    });
+
+    // 순환 참조(springboot <-> redis/rds) 회피를 위해 SG 룰은 별도 리소스로 분리 생성
+    new aws.ec2.SecurityGroupRule("springboot-from-alb-8080", {
+        type: "ingress",
+        securityGroupId: springbootSg.id,
+        sourceSecurityGroupId: albSg.id,
+        protocol: "tcp",
+        fromPort: 8080,
+        toPort: 8080,
+    });
+
+    new aws.ec2.SecurityGroupRule("springboot-from-bastion-ssh", {
+        type: "ingress",
+        securityGroupId: springbootSg.id,
+        sourceSecurityGroupId: bastionSg.id,
+        protocol: "tcp",
+        fromPort: 22,
+        toPort: 22,
+    });
+
+    new aws.ec2.SecurityGroupRule("redis-from-springboot-6379", {
+        type: "ingress",
+        securityGroupId: redisSg.id,
+        sourceSecurityGroupId: springbootSg.id,
+        protocol: "tcp",
+        fromPort: 6379,
+        toPort: 6379,
+    });
+
+    new aws.ec2.SecurityGroupRule("redis-from-bastion-ssh", {
+        type: "ingress",
+        securityGroupId: redisSg.id,
+        sourceSecurityGroupId: bastionSg.id,
+        protocol: "tcp",
+        fromPort: 22,
+        toPort: 22,
+    });
+
+    new aws.ec2.SecurityGroupRule("rds-from-springboot-3306", {
+        type: "ingress",
+        securityGroupId: rdsSg.id,
+        sourceSecurityGroupId: springbootSg.id,
+        protocol: "tcp",
+        fromPort: 3306,
+        toPort: 3306,
+    });
+
+    return { albSg, bastionSg, springbootSg, redisSg, rdsSg };
+}

--- a/infra/modules/securityGroups.ts
+++ b/infra/modules/securityGroups.ts
@@ -1,4 +1,5 @@
 import * as aws from "@pulumi/aws";
+import { config } from "../config";
 
 export interface SecurityGroupsResult {
     albSg: aws.ec2.SecurityGroup;
@@ -20,9 +21,11 @@ export function createSecurityGroups(vpcId: aws.ec2.Vpc["id"]): SecurityGroupsRe
         tags: { Name: "hello-prod-alb-sg" },
     });
 
-    // 기존에 실제 운영 중인 NAT 인스턴스가 붙어 있는 보안그룹을 그대로 import한다
-    // (pulumi import, README 참고). 현재 룰이 0.0.0.0/0 전체 허용으로 다소 느슨하지만,
-    // "있는 그대로 흡수"가 목표이므로 임의로 좁히지 않고 실제 상태를 그대로 코드에 반영한다.
+    // 기존에 실제 운영 중인 NAT 인스턴스가 붙어 있는 보안그룹을 pulumi import로 흡수했다
+    // (README 참고). 원래는 0.0.0.0/0 전체 프로토콜 허용이었으나, 외부 포트스캔으로 실제
+    // 열려있는 포트가 22(SSH)뿐임을 확인 - 보안그룹은 stateful이라 NAT 포워딩(프라이빗
+    // 서브넷의 아웃바운드 리턴 트래픽)에는 인터넷발 인바운드 룰이 필요 없다. 인터넷 노출은
+    // SSH만 남기고, VPC 내부(172.16.0.0/24) 전체 허용은 NAT 포워딩용으로 유지한다.
     const bastionSg = new aws.ec2.SecurityGroup(
         "hellogsm-nat-sg",
         {
@@ -31,7 +34,8 @@ export function createSecurityGroups(vpcId: aws.ec2.Vpc["id"]): SecurityGroupsRe
             // 실제 값("hellogsm-nat-sg")과 정확히 동일하게 맞춘다.
             description: "hellogsm-nat-sg",
             ingress: [
-                { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0", "172.16.0.0/24"] },
+                { protocol: "tcp", fromPort: 22, toPort: 22, cidrBlocks: [config.adminSshCidr] },
+                { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["172.16.0.0/24"] },
             ],
             egress: [{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] }],
             tags: { Name: "hellogsm-nat-sg" },

--- a/infra/modules/securityGroups.ts
+++ b/infra/modules/securityGroups.ts
@@ -59,7 +59,7 @@ export function createSecurityGroups(vpcId: aws.ec2.Vpc["id"]): SecurityGroupsRe
 
     const rdsSg = new aws.ec2.SecurityGroup("hello-prod-rds-sg", {
         vpcId,
-        description: "RDS MySQL - allow 3306 from Spring Boot",
+        description: "RDS MySQL - allow 3306 from Spring Boot and Bastion",
         egress: [{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] }],
         tags: { Name: "hello-prod-rds-sg" },
     });
@@ -105,6 +105,17 @@ export function createSecurityGroups(vpcId: aws.ec2.Vpc["id"]): SecurityGroupsRe
         type: "ingress",
         securityGroupId: rdsSg.id,
         sourceSecurityGroupId: springbootSg.id,
+        protocol: "tcp",
+        fromPort: 3306,
+        toPort: 3306,
+    });
+
+    // 아키텍처 다이어그램상 Bastion+NAT -> db -> MySQL 경로 - 관리자가 Bastion을 경유해
+    // SSH 터널링으로 RDS에 직접 접근(점검/마이그레이션 등)할 수 있도록 허용
+    new aws.ec2.SecurityGroupRule("rds-from-bastion-3306", {
+        type: "ingress",
+        securityGroupId: rdsSg.id,
+        sourceSecurityGroupId: bastionSg.id,
         protocol: "tcp",
         fromPort: 3306,
         toPort: 3306,

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,0 +1,2708 @@
+{
+  "name": "hellogsm-infra",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hellogsm-infra",
+      "version": "1.0.0",
+      "dependencies": {
+        "@pulumi/aws": "^6.66.0",
+        "@pulumi/pulumi": "^3.145.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+      "license": "ISC"
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@logdna/tail-file": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@logdna/tail-file/-/tail-file-2.2.0.tgz",
+      "integrity": "sha512-XGSsWDweP80Fks16lwkAUIr54ICyBs6PsI4mpfTLQaWgEJRtY9xEV+PeyDpJ+sJEGZxqINlpmAwe/6tS1pP8Ng==",
+      "license": "SEE LICENSE IN LICENSE",
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+      "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/arborist": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.9.1.tgz",
+      "integrity": "sha512-K0mr16xJ/yiTApeGIFbpgZSvJFOvxO2VJnCBhP543t9NTlHzgL+ewpG0kaWv9xkjeESAlRWHG9Q4lbT/LqHbWw==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/metavuln-calculator": "^9.0.2",
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/query": "^5.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "bin-links": "^6.0.0",
+        "cacache": "^20.0.1",
+        "common-ancestor-path": "^2.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-stringify-nice": "^1.1.4",
+        "lru-cache": "^11.2.1",
+        "minimatch": "^10.0.3",
+        "nopt": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "pacote": "^21.0.2",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.0.0",
+        "proggy": "^4.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^3.0.1",
+        "semver": "^7.3.7",
+        "ssri": "^13.0.0",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^4.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+      "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
+        "lru-cache": "^11.2.1",
+        "npm-pick-manifest": "^11.0.1",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/installed-package-contents": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+      "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "bin": {
+        "installed-package-contents": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
+      "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "glob": "^13.0.0",
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/metavuln-calculator": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
+      "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^20.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "pacote": "^21.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/name-from-folder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
+      "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/node-gyp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
+      "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+      "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^7.0.0",
+        "glob": "^13.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.5.3",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+      "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
+      "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/run-script": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
+      "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "node-gyp": "^12.1.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.220.0.tgz",
+      "integrity": "sha512-bv1xmNhmNwIM6MdUBw4yYuJeVcEViVLk3uD69vOQMwueHBnfyl/u0HnBlB1FNY/Te0UOzJzvcbyR8wN6b+iGbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/otlp-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-transformer": "0.220.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.10.0.tgz",
+      "integrity": "sha512-7gsvgf0UDoJ4l9ObrwBmz5G/ZogiPk+lq+g5GpLp24YQF/vPM/BSsnOfcLnfinast5ASUgLo78uSC/ObjlnXgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-grpc": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.220.0.tgz",
+      "integrity": "sha512-U1EF8KKu52XwH2ybUkjVDmaVQZGf3mXirRSw1KJQrOV5aymgJgkPJV7+kRPqawZe0rpVc/BK+pPSyMWuQoyJJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "0.220.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+      "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-transformer": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.220.0.tgz",
+      "integrity": "sha512-/eIkBPMBTIvM3x/0mDX4aJeSkYifYClnBPr68PL1h5LV4VQv4+SV6CGrpiZ4fIWDnobVmhTWCm1J/QRdAWUfvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-transformer": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+      "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-logs": "0.220.0",
+        "@opentelemetry/sdk-metrics": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+      "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@pulumi/aws": {
+      "version": "6.83.4",
+      "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-6.83.4.tgz",
+      "integrity": "sha512-mk3LhRJF6BdOq7VAWtrZpv+loLdaPxvbOVTESommiYXlSX87xXA8mytQCaeIXaivtpdj+xcBOJ8vz0A0Ktmw9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@pulumi/pulumi": "^3.142.0",
+        "mime": "^2.0.0"
+      }
+    },
+    "node_modules/@pulumi/pulumi": {
+      "version": "3.258.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.258.0.tgz",
+      "integrity": "sha512-IUds2PGz92YiaOSvegK6p5JjPdu0we+IcS9iClyaXRWWjxn7Po+omRoe/NJ58A0fpZFIZUUKM8+Lg7gYd1RczA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.1",
+        "@logdna/tail-file": "^2.0.6",
+        "@npmcli/arborist": "^9.0.0",
+        "@opentelemetry/api": "^1.9",
+        "@opentelemetry/core": "^2.9",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.220",
+        "@opentelemetry/exporter-zipkin": "^2.9",
+        "@opentelemetry/instrumentation": "^0.220",
+        "@opentelemetry/instrumentation-grpc": "^0.220",
+        "@opentelemetry/resources": "^2.9",
+        "@opentelemetry/sdk-trace-base": "^2.9",
+        "@opentelemetry/sdk-trace-node": "^2.9",
+        "@opentelemetry/semantic-conventions": "^1.42",
+        "@types/google-protobuf": "^3.15.5",
+        "@types/semver": "^7.5.6",
+        "execa": "^5.1.0",
+        "google-protobuf": "^3.21.4",
+        "ini": "^2.0.0",
+        "js-yaml": "^4.0.0",
+        "minimist": "^1.2.6",
+        "normalize-package-data": "^6.0.0",
+        "require-from-string": "^2.0.1",
+        "semver": "^7.5.2",
+        "source-map-support": "^0.5.6",
+        "upath": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "ts-node": ">= 7.0.1 < 12",
+        "typescript": ">= 3.8.3 < 7"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sigstore/bundle": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
+      "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/core": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/protobuf-specs": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
+      "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@sigstore/sign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+      "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/tuf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+      "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "tuf-js": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/verify": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.1.tgz",
+      "integrity": "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@tufjs/canonical-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@tufjs/models": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
+      "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@types/google-protobuf": {
+      "version": "3.15.12",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.12.tgz",
+      "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bin-links": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.2.tgz",
+      "integrity": "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w==",
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore-walk": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+      "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+      "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
+      "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/just-diff": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
+      "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
+      "license": "MIT"
+    },
+    "node_modules/just-diff-apply": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
+      "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "15.0.6",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+      "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/npm-bundled": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+      "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-install-checks": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+      "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-packlist": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+      "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^8.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-pick-manifest": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+      "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-registry-fetch": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+      "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/redact": "^4.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^15.0.0",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^13.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pacote": {
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
+      "integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "cacache": "^20.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^13.0.0",
+        "npm-packlist": "^10.0.1",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0",
+        "tar": "^7.4.3"
+      },
+      "bin": {
+        "pacote": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/parse-conflict-json": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
+      "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^5.0.0",
+        "just-diff": "^6.0.0",
+        "just-diff-apply": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/proggy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
+      "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/promise-call-limit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
+      "integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/sigstore": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.1.tgz",
+      "integrity": "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/treeverse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
+      "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/tuf-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
+      "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "hellogsm-infra",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.ts",
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  },
+  "dependencies": {
+    "@pulumi/aws": "^6.66.0",
+    "@pulumi/pulumi": "^3.145.0"
+  }
+}

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "files": [
+    "index.ts"
+  ],
+  "include": [
+    "modules/**/*.ts",
+    "config.ts"
+  ]
+}

--- a/infra/userdata/bastion-nat.sh
+++ b/infra/userdata/bastion-nat.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euxo pipefail
+
+# 1. IP forwarding 영구 활성화
+cat <<'EOF' > /etc/sysctl.d/99-nat.conf
+net.ipv4.ip_forward = 1
+EOF
+sysctl -p /etc/sysctl.d/99-nat.conf
+
+# 2. iptables 설치 (Amazon Linux 2023 기본 미설치)
+dnf install -y iptables iptables-services
+
+# 3. NAT(MASQUERADE) 규칙 설정 - VPC 내부(172.16.0.0/24)에서 나가는 트래픽을 외부로 마스커레이딩
+PRIMARY_IF=$(ip route show default | awk '{print $5}' | head -n1)
+iptables -t nat -A POSTROUTING -o "$PRIMARY_IF" -s 172.16.0.0/24 -j MASQUERADE
+iptables -A FORWARD -i "$PRIMARY_IF" -o "$PRIMARY_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+# 4. 재부팅 시에도 유지되도록 규칙 저장
+mkdir -p /etc/sysconfig
+iptables-save > /etc/sysconfig/iptables
+systemctl enable iptables
+systemctl start iptables

--- a/infra/userdata/redis-ec2.sh
+++ b/infra/userdata/redis-ec2.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euxo pipefail
+
+dnf install -y docker
+systemctl enable docker
+systemctl start docker
+
+docker run -d \
+  --name hellogsm-prod-redis \
+  --restart unless-stopped \
+  -p 6379:6379 \
+  redis:7-alpine
+
+timedatectl set-timezone Asia/Seoul

--- a/infra/userdata/springboot-ec2.sh
+++ b/infra/userdata/springboot-ec2.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euxo pipefail
+
+# 1. Docker 설치 및 기동
+dnf install -y docker
+systemctl enable docker
+systemctl start docker
+usermod -aG docker ec2-user
+
+# 2. CodeDeploy agent 설치 (Amazon Linux 2023 기준)
+dnf install -y ruby wget
+cd /home/ec2-user
+wget https://aws-codedeploy-ap-northeast-2.s3.ap-northeast-2.amazonaws.com/latest/install
+chmod +x ./install
+./install auto
+systemctl enable codedeploy-agent
+systemctl start codedeploy-agent
+
+# 3. 시간대 설정 (앱/로그 타임스탬프 일치)
+timedatectl set-timezone Asia/Seoul

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -123,6 +123,13 @@ management:
   endpoint:
     prometheus:
       access: read_only
+    health:
+      group:
+        # ALB 타겟그룹 헬스체크 전용. 기본 집계 health는 db/redis/diskSpace를 전부 포함해
+        # 인스턴스 1대 구성에서 캐시/디스크 경고만으로도 서비스 전체가 ALB에서 빠지므로,
+        # 앱 프로세스 생존 여부(ping)만 보는 별도 그룹을 둔다.
+        liveness:
+          include: ping
 discord-alarm:
   url: ${DISCORD_RELAY_SERVER_URL}
   api-key: ${DISCORD_RELAY_SERVER_API_KEY}


### PR DESCRIPTION
## 개요

상용(production) AWS 인프라를 Pulumi(TypeScript)로 관리하도록 `infra/` 프로젝트를 추가했습니다. 기존에 수동으로 만들어져 있던 VPC/NAT/CodeDeploy/로그그룹은 그대로 import해서 흡수했고, RDS·ALB·Spring Boot/Redis EC2·IAM 등은 새로 코드로 정의했습니다. 실제로 `pulumi up`까지 실행해 정상 동작(ALB/ACM/DNS/HTTPS 리다이렉트)을 확인한 뒤, 검증용으로 새로 만든 리소스만 `pulumi destroy --exclude-protected`로 되돌려 기존 운영 리소스에는 영향을 주지 않았습니다.

## 본문

### 추가

- `infra/` : Pulumi(TypeScript) 상용 인프라 프로젝트
  - `modules/network.ts`, `securityGroups.ts` : 기존 VPC(`hello-vpc`)·서브넷 4개·라우트테이블·NAT 보안그룹을 import 기준으로 선언
  - `modules/compute/bastionNat.ts` : 기존 Bastion+NAT 인스턴스(`hello-prod-nat`)를 실제 스펙(AMI, `t4g.micro`, 기존 키페어)에 맞춰 import
  - `modules/compute/springbootServer.ts`, `redisServer.ts` : 신규 Spring Boot / Redis EC2
  - `modules/database.ts` : 신규 RDS MySQL (`multiAz:false`, 암호화, 7일 백업 보관)
  - `modules/alb.ts`, `dnsCert.ts` : 신규 ALB + ACM 인증서 + Route53 `api-prod.hellogsm.kr` 레코드 (Hosted Zone은 기존 것을 데이터소스로만 참조)
  - `modules/iam.ts` : Spring Boot 인스턴스 프로파일, CodeDeploy 서비스 롤, GitHub OIDC 배포 롤 신규 생성
  - `modules/codeDeploy.ts` : 기존 CodeDeploy 애플리케이션/배포그룹(`hellogsm-prod-codedeploy` / `api-prod-hellogsm-kr`)을 import 후 Blue/Green(ASG, 이미 삭제됨)에서 In-place + EC2 태그 필터 방식으로 갱신
  - `modules/monitoring.ts` : 기존 로그그룹(`hellogsm-prod-log`, 1GB+ 운영 로그 보유)을 import, ALB/EC2 상태 알람 + SNS Topic 신규 생성
  - 기존 운영 중인 리소스(VPC/서브넷/라우트테이블/NAT/EIP/보안그룹/CodeDeploy 앱·그룹/로그그룹/S3 버킷 2종)는 전부 `protect: true`로 걸어 실수로 삭제되지 않도록 함 — 특히 `hello-pub-rtb`는 stage 환경과 공유되는 라우트테이블이라 별도로 명시
  - `README.md` : bootstrap 절차, 재해복구용 import 명령 전체, 운영 절차, 검증 방법 문서화

### 변경

- `.github/workflows/hellogsm-prod-cd.yml` : 정적 AWS 액세스키(`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`) 방식을 GitHub OIDC 기반 `role-to-assume`으로 전환 (`id-token: write` 권한 추가, `AWS_PROD_DEPLOY_ROLE_ARN` Repository Variable 필요)

### 리뷰 반영 (추가 커밋)

- `fix`: `githubRepo` 설정값이 `hellogsm-server-25`로 남아있던 걸 실제 저장소명 `hellogsm-server-26`으로 수정 (OIDC trust policy `sub` 조건 불일치 버그)
- `fix`: `hellogsm-nat-sg` 인터넷 인바운드를 `0.0.0.0/0` 전체 프로토콜 허용에서 `adminSshCidr`발 SSH(22)만으로 축소. 외부 포트스캔으로 실제 사용 포트가 22뿐임을 확인 후 운영 중인 SG에 즉시 적용 및 재검증 완료
- `fix`: 원본 아키텍처 다이어그램(Bastion+NAT → db → MySQL)과 대조해보니 RDS 보안그룹에 Bastion 경유 3306 접근 규칙이 누락되어 있어 추가 (관리자가 Bastion을 통해 SSH 터널링으로 RDS에 직접 접근할 수 있도록)
- SNS `Resource: "*"`는 반영하지 않음 — 앱이 `SnsSmsTemplate`로 전화번호 지정 직접 SMS 발송만 사용해 Topic ARN이 존재하지 않는 발행 방식이라 리소스 레벨로 좁힐 수 없음 (AWS 제약, 코드 주석에 근거 명시)

### 리뷰 반영 2차 (실제 배포 담당자 리뷰, 17건)

- `fix`: AMI `mostRecent` 필터를 `al2023-ami-2023.*-kernel-6.1-x86_64`로 좁히고(minimal 변형 오매치 방지), springboot 인스턴스에 `ignoreChanges: ["ami", "userData"]` 추가 — 둘 다 교체/재기동 시 앱이 수동 재배포 전까지 다운되는 문제였음
- `fix`: `logs:CreateLogGroup` IAM 권한 누락 수정 — `CloudWatchAppender`가 기동 시 무조건 이 액션을 호출해서, 없으면 prod 로그가 한 줄도 안 쌓이는 상태였음
- `fix`: 존재하지 않는 IAM 액션(`codedeploy:PollHostCommand` 등) 삭제, 실제 필요한 CodeDeploy agent installer S3 권한(`aws-codedeploy-ap-northeast-2`)으로 교체
- `fix`: `index.ts`의 NAT Route 2개 + `network.ts`의 RouteTableAssociation 4개에 `protect:true` 누락 수정, EC2 인스턴스에 NAT route `dependsOn` 추가(DR 시나리오 경쟁 조건 방지)
- `fix`: 퍼블릭 라우트테이블 2개의 인라인 `routes`(authoritative라 코드에 없는 라우트를 다음 up에서 삭제함)를 분리형 `aws.ec2.Route`로 전환 — `hello-pub-rtb`가 stage와 공유되는 구조라 특히 위험했음. 다만 "prod 스택이 공유 라우트테이블을 소유해도 되는가"라는 더 근본적인 질문은 아직 해소 안 됨(실제 라우팅 재구성이 필요해 별도 논의 필요)
- `fix`: CodeDeploy `WITHOUT_TRAFFIC_CONTROL` → `WITH_TRAFFIC_CONTROL` + `loadBalancerInfo` — 배포 중 ALB가 죽은 타겟에 계속 트래픽을 보내던 문제
- `fix`: ALB 타겟그룹 헬스체크를 집계 `/health`에서 `/health/liveness`로 변경, `application.yml`에 해당 헬스 그룹 추가 — Redis 순단 하나로 서비스 전체가 ALB에서 빠지는 문제
- `fix`: RDS `deletionProtection: true` 추가 + `finalSnapshotIdentifier` 충돌 가능성 주석 명시
- `fix`: README DR import 목록에 OIDC provider/IAM 롤 3개/RDS subnet group/SNS/ALB/TG 추가, ALB alias 레코드에 `allowOverwrite` 추가
- `fix`: README에 정적 액세스키 삭제는 stage CD도 OIDC 전환한 뒤에 하라는 선행조건 명시(지금 삭제하면 stage CD가 즉시 깨짐)
- `fix`: `workflow_dispatch`는 반드시 main 브랜치로 실행해야 한다는 주의사항 README에 추가, OIDC thumbprint 관련 stale 주석 정정
- `fix`: `infra/userdata/bastion-nat.sh`가 어디서도 참조 안 되는 파일이라는 점과 DR 시 수동 적용 필요성을 README에 명시
- `fix`: 죽은 config `bastionInstanceType` 삭제(코드+라이브 스택 config), `keyPairName`이 springboot/redis에만 쓰이고 bastion에는 실제 하드코딩된 값이 쓰인다는 점 주석으로 명시
- `fix`: 레포 잔존 `hellogsm-server-25` 표기(`Pulumi.yaml`, `README.md` 제목) 정리
- `fix`: SG 인라인 룰과 독립 `SecurityGroupRule` 혼용 시 위험(나중에 인라인 ingress 추가하면 조용히 덮어써짐) 경고 주석 추가
- `fix`: `snsAlarmEmail`을 `themoment.hellogsm@gmail.com`으로 설정 — `pulumi up` 시 해당 주소로 SNS 구독 확인 메일이 발송되며, 확인 전까지는 알람이 실제로 수신되지 않음
- 반영 불가 확인: 실제 CD 배포 테스트는 이 PR 범위에서 진행하지 않음(RDS/EC2/ALB를 검증 후 destroy했기 때문 — 별도로 다시 `pulumi up` 후 실배포 검증 필요)

## 검증

- `pulumi preview` : import 이후 diff가 replace/delete 없이 create/update로만 정리됨을 확인
- `pulumi up` 실제 실행 → RDS `available`, EC2 상태체크 정상, ALB `active`, ACM `ISSUED`, `api-prod.hellogsm.kr` DNS 정상 resolve, HTTP→HTTPS 301 리다이렉트, HTTPS 502(앱 미배포 상태라 정상) 확인
- `pulumi destroy --exclude-protected` 실행 → 새로 만든 35개 리소스 정리. 코드상 `protect:true`는 당시 18개뿐이었고, 나머지(RDS 포함)는 `pulumi state protect`/`unprotect`로 CLI에서 수동 조정한 상태였다(코드에 반영 안 되어 있던 게 리뷰로 지적됨, 이후 커밋에서 Route×2/RouteTableAssociation×4에 protect 추가로 코드-state 불일치 해소). RDS는 이때 수동으로 unprotect 후 삭제해 최종 스냅샷이 실제로 생성됐음을 `aws rds describe-db-snapshots`로 확인
- 원본 아키텍처 다이어그램 + VPC/ALB 리소스맵과 코드/실제 AWS 상태를 재대조 (아래 "후속 작업" 중 처음 두 항목이 이 과정에서 확인됨)

## 후속 작업 (이번 PR 범위 밖)

- `hello-monitoring-private-2a` 서브넷(172.16.0.192/27)이 리소스맵상 설계에는 있으나 AWS에 아직 생성된 적이 없음 — Monitoring 환경 자체가 미구축 상태, 이번 prod 스코프 밖
- CloudWatch → Discord 알림 연동 (레포에 기존 메커니즘 없어 이번 범위 제외, SNS Topic까지만 구성)
- RDS `multiAz: false` — 비용 절감을 위한 의도적 선택 (Multi-AZ 전환 시 RDS 비용 약 2배). 고가용성이 필요해지면 별도 논의 후 전환
- `pulumi up` 재실행 후 GitHub Secret `PROD_WEB_YML`을 새 RDS/Redis 엔드포인트로 갱신, `AWS_PROD_DEPLOY_ROLE_ARN` Repository Variable 등록

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
c: 웬만하면 반영해 주세요. (Comment)
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


