### PR TITLE
[oneseo] 생기부 추출 로그에 텍스트 레이어 여부 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractMiddleSchoolAchievementService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractMiddleSchoolAchievementService.java
@@ -50,9 +50,10 @@ public class ExtractMiddleSchoolAchievementService {
 
         ExtractedAchievementResDto result = parser
                 .parse(extractedText, reqDto.graduationType(), reqDto.liberalSystem());
-        log.info("생활기록부 성적 추출 완료. memberId={}, source={}, confidence={}, warningCount={}",
+        log.info("생활기록부 성적 추출 완료. memberId={}, source={}, hasTextLayer={}, confidence={}, warningCount={}",
                 memberId,
                 extractedText.source(),
+                extractedText.hasTextLayer(),
                 result.meta().confidence(),
                 result.meta().warnings().size());
 


### PR DESCRIPTION
## 배경
생기부 OCR 정확도 개선 작업 사양의 작업1(로깅 추가)입니다. 순수 스캔본(텍스트 레이어 없음) 지원자 비율을 데이터로 파악해 후속 작업(kordoc 서버 OCR 연동 등)의 투자 우선순위를 판단하기 위한 선행 작업입니다.

## 변경 사항
- `ExtractMiddleSchoolAchievementService`의 추출 완료 로그에 `hasTextLayer` 필드를 추가했습니다.
- 기존에도 `source`(TEXT_LAYER/OCR), `confidence`는 로깅되고 있었으며, 이번에 `hasTextLayer`만 보강했습니다.
- `rawText` 등 개인정보는 로깅하지 않습니다.

## 검증
- `ExtractMiddleSchoolAchievementServiceTest` 통과
- `./gradlew spotlessApply` 적용