### PR TITLE
[oneseo] kordoc 기반 서버 OCR 페이지 인식 API 추가

### DIFF
--- a/DockerfileProd
+++ b/DockerfileProd
@@ -16,7 +16,10 @@ WORKDIR /app
 
 ARG JAR_FILE=build/libs/*.jar
 
-COPY --from=ocr-tools /usr/local /usr/local
+# /usr/local 전체를 복사하지 않고 node/npm/npx 실행 파일과 전역 설치된 kordoc 패키지 경로만 가져와,
+# eclipse-temurin 이미지에 이미 있는 /usr/local 하위 파일과 충돌할 여지를 줄입니다.
+COPY --from=ocr-tools /usr/local/bin /usr/local/bin
+COPY --from=ocr-tools /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 COPY ${JAR_FILE} hellogsm-prod-server.jar
 

--- a/DockerfileProd
+++ b/DockerfileProd
@@ -1,3 +1,13 @@
+# kordoc(생기부 스캔 페이지 서버 OCR)을 빌드 시점에 설치합니다.
+# TODO: kordoc은 최초 사용 시 OCR 모델(~18MB)을 자동 다운로드합니다. 런타임에 매번 네트워크가 필요하지 않도록
+# 빌드 시점에 모델을 미리 받아 COPY하는 워밍업 단계가 필요하지만, 정확한 모델 캐시 경로를 실제 kordoc 실행으로
+# 확인하지 못해 이번 변경에서는 보류했습니다. 실제 Node 환경에서 --ocr 플래그로 한 번 실행해 캐시 경로를 확인한 뒤
+# 이 스테이지에 워밍업 RUN과 COPY를 추가해주세요. 그 전까지는 컨테이너의 첫 OCR 요청에서 모델 다운로드 네트워크
+# 호출이 한 번 발생합니다.
+FROM node:22-slim AS ocr-tools
+
+RUN npm install -g @clazic/kordoc
+
 FROM eclipse-temurin:25-jre
 
 EXPOSE 8080
@@ -5,6 +15,8 @@ EXPOSE 8080
 WORKDIR /app
 
 ARG JAR_FILE=build/libs/*.jar
+
+COPY --from=ocr-tools /usr/local /usr/local
 
 COPY ${JAR_FILE} hellogsm-prod-server.jar
 

--- a/DockerfileStage
+++ b/DockerfileStage
@@ -1,3 +1,13 @@
+# kordoc(생기부 스캔 페이지 서버 OCR)을 빌드 시점에 설치합니다.
+# TODO: kordoc은 최초 사용 시 OCR 모델(~18MB)을 자동 다운로드합니다. 런타임에 매번 네트워크가 필요하지 않도록
+# 빌드 시점에 모델을 미리 받아 COPY하는 워밍업 단계가 필요하지만, 정확한 모델 캐시 경로를 실제 kordoc 실행으로
+# 확인하지 못해 이번 변경에서는 보류했습니다. 실제 Node 환경에서 --ocr 플래그로 한 번 실행해 캐시 경로를 확인한 뒤
+# 이 스테이지에 워밍업 RUN과 COPY를 추가해주세요. 그 전까지는 컨테이너의 첫 OCR 요청에서 모델 다운로드 네트워크
+# 호출이 한 번 발생합니다.
+FROM node:22-slim AS ocr-tools
+
+RUN npm install -g @clazic/kordoc
+
 FROM eclipse-temurin:25-jre
 
 EXPOSE 8080
@@ -5,6 +15,8 @@ EXPOSE 8080
 WORKDIR /hellogsm-server-v3
 
 ARG JAR_FILE=build/libs/*.jar
+
+COPY --from=ocr-tools /usr/local /usr/local
 
 COPY ${JAR_FILE} hellogsm-stage-server.jar
 

--- a/DockerfileStage
+++ b/DockerfileStage
@@ -16,7 +16,10 @@ WORKDIR /hellogsm-server-v3
 
 ARG JAR_FILE=build/libs/*.jar
 
-COPY --from=ocr-tools /usr/local /usr/local
+# /usr/local 전체를 복사하지 않고 node/npm/npx 실행 파일과 전역 설치된 kordoc 패키지 경로만 가져와,
+# eclipse-temurin 이미지에 이미 있는 /usr/local 하위 파일과 충돌할 여지를 줄입니다.
+COPY --from=ocr-tools /usr/local/bin /usr/local/bin
+COPY --from=ocr-tools /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 COPY ${JAR_FILE} hellogsm-stage-server.jar
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoExtractionController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoExtractionController.java
@@ -1,8 +1,11 @@
 package team.themoment.hellogsmv3.domain.oneseo.controller;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,7 +13,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ExtractMiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ExtractedAchievementResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrPageTextResDto;
 import team.themoment.hellogsmv3.domain.oneseo.service.ExtractMiddleSchoolAchievementService;
+import team.themoment.hellogsmv3.domain.oneseo.service.ExtractOcrPageTextService;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
 
 @Tag(name = "Oneseo Extraction API", description = "생활기록부 성적 추출 관련 API입니다.")
@@ -20,6 +25,7 @@ import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
 public class OneseoExtractionController {
 
     private final ExtractMiddleSchoolAchievementService extractMiddleSchoolAchievementService;
+    private final ExtractOcrPageTextService extractOcrPageTextService;
 
     @Operation(summary = "생활기록부 성적 추출", description = "클라이언트가 생활기록부에서 뽑아 보낸 텍스트를 중학교 성적으로 구조화합니다. 원본 파일은 서버로 전송되지 않으며, 원서 데이터를 수정하지 않습니다. 추출 결과는 사용자가 검토한 뒤 원서 등록 API로 제출해야 합니다.")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "추출 성공"),
@@ -29,5 +35,15 @@ public class OneseoExtractionController {
             @RequestBody @Valid ExtractMiddleSchoolAchievementReqDto reqDto,
             @AuthRequest Long memberId) {
         return extractMiddleSchoolAchievementService.execute(reqDto, memberId);
+    }
+
+    @Operation(summary = "생활기록부 스캔 페이지 OCR", description = "텍스트 레이어가 없는 페이지 한 장의 스캔 이미지를 서버로 받아 kordoc으로 인식하고, 위 성적 추출 API가 읽는 rawText 줄 형식으로 되돌려줍니다. 업로드된 이미지는 인식 처리 동안만 임시로 존재하며 처리 직후 삭제되고 서버에 저장되지 않습니다. 반환된 rawText는 클라이언트가 문서 전체 텍스트에서 이 페이지가 있던 자리에 이어붙인 뒤 위 성적 추출 API로 제출해야 합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "인식 성공"),
+            @ApiResponse(responseCode = "400", description = "파일이 없거나 지원하지 않는 확장자인 경우"),
+            @ApiResponse(responseCode = "503", description = "OCR 처리가 몰려 있어 즉시 처리할 수 없는 경우. 잠시 후 재시도")})
+    @PostMapping(value = "/middle-school-achievement/ocr-page", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public OcrPageTextResDto extractOcrPageText(
+            @Parameter(description = "스캔 페이지 이미지 (jpg, jpeg, png)") @RequestParam("file") MultipartFile file) {
+        return extractOcrPageTextService.execute(file);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/kordoc/KordocBlock.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/kordoc/KordocBlock.java
@@ -1,0 +1,30 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * kordoc {@code --format json} 출력의 블록입니다.
+ *
+ * <p>
+ * {@code type}이 {@code "table"}이면 {@code rows}가, 그 외(예: {@code "heading"},
+ * {@code "text"})면 {@code text}가 채워집니다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KordocBlock(String type, String text, List<KordocTableRow> rows, int pageNumber) {
+
+    public static final String TYPE_TABLE = "table";
+
+    public boolean isTable() {
+        return TYPE_TABLE.equals(type);
+    }
+
+    public List<KordocTableRow> rowsOrEmpty() {
+        return rows == null ? List.of() : rows;
+    }
+
+    public String textOrEmpty() {
+        return text == null ? "" : text;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/kordoc/KordocParseResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/kordoc/KordocParseResult.java
@@ -1,0 +1,17 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * kordoc {@code --format json} 출력 최상위 구조입니다. 문서 전체가 아니라 페이지 1장짜리 입력만 다루므로 필요한
+ * 필드만 매핑합니다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KordocParseResult(List<KordocBlock> blocks) {
+
+    public List<KordocBlock> blocksOrEmpty() {
+        return blocks == null ? List.of() : blocks;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/kordoc/KordocTableCell.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/kordoc/KordocTableCell.java
@@ -1,0 +1,17 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * kordoc {@code --format json} 출력의 표 셀입니다.
+ *
+ * @param text
+ *            셀 텍스트. 줄바꿈으로 구분된 여러 값이 한 셀에 뭉쳐 나올 수 있습니다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KordocTableCell(String text, int colSpan, int rowSpan) {
+
+    public String textOrEmpty() {
+        return text == null ? "" : text;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/kordoc/KordocTableRow.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/kordoc/KordocTableRow.java
@@ -1,0 +1,13 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KordocTableRow(List<KordocTableCell> cells) {
+
+    public List<KordocTableCell> cellsOrEmpty() {
+        return cells == null ? List.of() : cells;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/OcrPageTextResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/OcrPageTextResDto.java
@@ -1,0 +1,13 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+/** 스캔 페이지 한 장을 kordoc으로 인식해 되돌린 rawText 조각입니다. */
+@Builder
+public record OcrPageTextResDto(
+        @Schema(description = "이 페이지에서 재구성한 rawText 줄들. 문서 전체 rawText에서 이 페이지가 있던 위치에 그대로 이어붙이면 됩니다.") String rawText,
+        @Schema(description = "표준 과목 9개만으로 분해하지 못해 건너뛴 과목명 원문 목록. 비어 있지 않으면 직접 확인이 필요합니다.") List<String> unrecognizedSubjectBlobs) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
@@ -1,9 +1,12 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -74,10 +77,24 @@ public class ExtractOcrPageTextService {
         String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
         try {
             Path tempFile = Files.createTempFile("ocr-page-", "." + extension);
+            restrictToOwner(tempFile);
             file.transferTo(tempFile);
             return tempFile;
         } catch (IOException e) {
             throw new ExpectedException("업로드된 이미지를 처리하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /** 업로드된 스캔 이미지는 생활기록부 실물이므로, 임시 파일을 소유자만 읽고 쓸 수 있게 제한합니다. */
+    private void restrictToOwner(Path file) {
+        if (!FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            return;
+        }
+        try {
+            Files.setPosixFilePermissions(file,
+                    Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        } catch (IOException e) {
+            log.warn("업로드 임시 이미지 권한 설정 실패. path={}", file);
         }
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
@@ -1,0 +1,91 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocParseResult;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrPageTextResDto;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr.KordocAchievementTextConverter;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr.KordocConversionResult;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr.KordocOcrClient;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr.OcrConcurrencyGate;
+import team.themoment.sdk.exception.ExpectedException;
+
+/**
+ * 텍스트 레이어가 없는 생활기록부 페이지의 스캔 이미지를 kordoc으로 인식해, 기존
+ * {@link team.themoment.hellogsmv3.domain.oneseo.service.extraction.MiddleSchoolRecordParser}가
+ * 읽는 rawText 줄 형식으로 되돌립니다.
+ *
+ * <p>
+ * 업로드된 이미지는 kordoc 실행을 위해 임시 파일로만 잠깐 존재하고, 처리 직후(성공 · 실패 무관) 삭제되며 서버에 영구 저장되지
+ * 않습니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExtractOcrPageTextService {
+
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png");
+
+    private final KordocOcrClient kordocOcrClient;
+    private final KordocAchievementTextConverter converter;
+    private final OcrConcurrencyGate concurrencyGate;
+
+    public OcrPageTextResDto execute(MultipartFile file) {
+        validate(file);
+
+        Path tempImage = writeToTempFile(file);
+        try {
+            KordocParseResult parseResult = concurrencyGate.runWithinLimit(() -> kordocOcrClient.recognize(tempImage));
+            KordocConversionResult conversion = converter.convert(parseResult);
+
+            if (!conversion.unrecognizedSubjectBlobs().isEmpty()) {
+                log.warn("OCR 페이지에서 과목명 분해 실패. unrecognizedSubjectBlobCount={}",
+                        conversion.unrecognizedSubjectBlobs().size());
+            }
+
+            return OcrPageTextResDto.builder().rawText(conversion.rawText())
+                    .unrecognizedSubjectBlobs(conversion.unrecognizedSubjectBlobs()).build();
+        } finally {
+            deleteQuietly(tempImage);
+        }
+    }
+
+    private void validate(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new ExpectedException("파일이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+        String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        if (extension == null || !ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
+            throw new ExpectedException("지원하지 않는 파일 확장자입니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private Path writeToTempFile(MultipartFile file) {
+        String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        try {
+            Path tempFile = Files.createTempFile("ocr-page-", "." + extension);
+            file.transferTo(tempFile);
+            return tempFile;
+        } catch (IOException e) {
+            throw new ExpectedException("업로드된 이미지를 처리하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void deleteQuietly(Path file) {
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            log.warn("OCR 임시 이미지 삭제 실패. path={}", file);
+        }
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
@@ -75,12 +75,19 @@ public class ExtractOcrPageTextService {
 
     private Path writeToTempFile(MultipartFile file) {
         String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        Path tempFile;
         try {
-            Path tempFile = Files.createTempFile("ocr-page-", "." + extension);
-            restrictToOwner(tempFile);
+            tempFile = Files.createTempFile("ocr-page-", "." + extension);
+        } catch (IOException e) {
+            throw new ExpectedException("업로드된 이미지를 처리하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        restrictToOwner(tempFile);
+        try {
             file.transferTo(tempFile);
             return tempFile;
         } catch (IOException e) {
+            deleteQuietly(tempFile);
             throw new ExpectedException("업로드된 이미지를 처리하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverter.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverter.java
@@ -34,7 +34,9 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocTableRo
 @RequiredArgsConstructor
 public class KordocAchievementTextConverter {
 
-    private static final Pattern GRADE_MENTION = Pattern.compile("(\\d)?\\s*학년");
+    // 블록 텍스트 전체가 학년 표시 그 자체일 때만 인정합니다. 부분 일치를 허용하면 "2024학년도 생활기록부" 같은 제목이나
+    // "학년별 출결현황" 같은 캡션에도 반응해 엉뚱한 [N학년] 줄을 끼워 넣고, 문서 전체의 학년 판정을 틀어지게 합니다.
+    private static final Pattern GRADE_HEADING = Pattern.compile("^\\[?\\s*([1-3])?\\s*학년\\s*]?$");
     private static final Pattern BARE_SEMESTER = Pattern.compile("^[12]$");
     // 원점수/과목평균 부분은 SUBJECT_ROW와 동일하게 선택 사항입니다. 예체능처럼 성취도만 있는 과목이 이 표에 섞여
     // 나올 가능성을 배제할 수 없어, 점수 없이 성취도 글자만 있는 줄도 원점수/성취도 열로 인식합니다.
@@ -59,11 +61,14 @@ public class KordocAchievementTextConverter {
         return new KordocConversionResult(String.join("\n", lines), unrecognizedSubjectBlobs);
     }
 
-    /** 표가 아닌 블록에서 학년 표시(예: "1학년")를 찾아 파서가 요구하는 {@code [N학년]} 줄로 되살립니다. */
+    /**
+     * 표가 아닌 블록의 전체 텍스트가 학년 표시(예: "1학년", "[1학년]")뿐일 때만 파서가 요구하는 {@code [N학년]} 줄로
+     * 되살립니다.
+     */
     private void convertHeadingOrText(KordocBlock block, List<String> lines) {
-        String text = block.textOrEmpty();
-        Matcher matcher = GRADE_MENTION.matcher(text);
-        if (!matcher.find()) {
+        String text = block.textOrEmpty().strip();
+        Matcher matcher = GRADE_HEADING.matcher(text);
+        if (!matcher.matches()) {
             return;
         }
         String digit = matcher.group(1);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverter.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverter.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -35,8 +36,10 @@ public class KordocAchievementTextConverter {
 
     private static final Pattern GRADE_MENTION = Pattern.compile("(\\d)?\\s*학년");
     private static final Pattern BARE_SEMESTER = Pattern.compile("^[12]$");
+    // 원점수/과목평균 부분은 SUBJECT_ROW와 동일하게 선택 사항입니다. 예체능처럼 성취도만 있는 과목이 이 표에 섞여
+    // 나올 가능성을 배제할 수 없어, 점수 없이 성취도 글자만 있는 줄도 원점수/성취도 열로 인식합니다.
     private static final Pattern SCORE_LINE = Pattern
-            .compile("^[\\d.,\\s]+/[\\d.,\\s]+\\s*(?:\\([^)]*\\))?\\s+[A-EP]\\s*(?:\\(\\s*\\d+\\s*\\))?$");
+            .compile("^(?:[\\d.,\\s]+/[\\d.,\\s]+\\s*(?:\\([^)]*\\))?\\s+)?[A-EP]\\s*(?:\\(\\s*\\d+\\s*\\))?$");
     private static final Pattern HANGUL = Pattern.compile("[가-힣]");
 
     private final KordocSubjectTokenizer subjectTokenizer;
@@ -106,8 +109,8 @@ public class KordocAchievementTextConverter {
     /** 과목명 열: 원점수 셀도, 학기 숫자 하나짜리 셀도 아니면서 한글이 가장 많이 포함된 셀입니다. */
     private Optional<KordocTableCell> findSubjectCell(List<KordocTableCell> cells, KordocTableCell scoreCell) {
         return cells.stream().filter(cell -> cell != scoreCell)
-                .filter(cell -> !BARE_SEMESTER.matcher(cell.textOrEmpty().strip()).matches()).max((first,
-                        second) -> Integer.compare(countHangul(first.textOrEmpty()), countHangul(second.textOrEmpty())))
+                .filter(cell -> !BARE_SEMESTER.matcher(cell.textOrEmpty().strip()).matches())
+                .max(Comparator.comparingInt(cell -> countHangul(cell.textOrEmpty())))
                 .filter(cell -> countHangul(cell.textOrEmpty()) > 0);
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverter.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverter.java
@@ -1,0 +1,136 @@
+package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocBlock;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocParseResult;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocTableCell;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocTableRow;
+
+/**
+ * kordoc {@code --format json} 표 재구성 결과를
+ * {@link team.themoment.hellogsmv3.domain.oneseo.service.extraction.MiddleSchoolRecordParser}가
+ * 원래 읽던 줄 형식으로 되돌립니다.
+ *
+ * <p>
+ * 새로운 파서를 만들지 않고, 이미 실제 생활기록부로 검증된 기존 파서를 그대로 재사용하는 것이 목표입니다. 표가 아닌 블록(제목 등)에서
+ * 학년 표시를 복원하고, 표 블록의 각 행에서 원점수/성취도 열(줄바꿈으로 분리됨)과 과목명 열(구분자 없이 붙어 있음)을 찾아 짝을
+ * 맞춥니다. 어떤 열이 무엇인지 표에 명시되어 있지 않으므로, 각 열의 텍스트 모양으로 역할을 추정합니다.
+ *
+ * <p>
+ * 짝을 맞추지 못한 행은 억지로 밀어 넣지 않고 건너뛰며, 그 과목명 원문을 {@code unrecognizedSubjectBlobs}로
+ * 돌려주어 사용자 검수를 요청합니다. 표 모양을 추정하지 못한 행(출결 · 봉사 등)은 셀을 그대로 이어붙여 지나가는 줄로 남겨둡니다 —
+ * 기존 파서의 정규식은 정확히 일치하는 줄만 소비하므로, 맞지 않는 줄이 섞여도 무시될 뿐 다른 결과를 해치지 않습니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class KordocAchievementTextConverter {
+
+    private static final Pattern GRADE_MENTION = Pattern.compile("(\\d)?\\s*학년");
+    private static final Pattern BARE_SEMESTER = Pattern.compile("^[12]$");
+    private static final Pattern SCORE_LINE = Pattern
+            .compile("^[\\d.,\\s]+/[\\d.,\\s]+\\s*(?:\\([^)]*\\))?\\s+[A-EP]\\s*(?:\\(\\s*\\d+\\s*\\))?$");
+    private static final Pattern HANGUL = Pattern.compile("[가-힣]");
+
+    private final KordocSubjectTokenizer subjectTokenizer;
+
+    public KordocConversionResult convert(KordocParseResult parseResult) {
+        List<String> lines = new ArrayList<>();
+        List<String> unrecognizedSubjectBlobs = new ArrayList<>();
+
+        for (KordocBlock block : parseResult.blocksOrEmpty()) {
+            if (block.isTable()) {
+                convertTable(block, lines, unrecognizedSubjectBlobs);
+            } else {
+                convertHeadingOrText(block, lines);
+            }
+        }
+
+        return new KordocConversionResult(String.join("\n", lines), unrecognizedSubjectBlobs);
+    }
+
+    /** 표가 아닌 블록에서 학년 표시(예: "1학년")를 찾아 파서가 요구하는 {@code [N학년]} 줄로 되살립니다. */
+    private void convertHeadingOrText(KordocBlock block, List<String> lines) {
+        String text = block.textOrEmpty();
+        Matcher matcher = GRADE_MENTION.matcher(text);
+        if (!matcher.find()) {
+            return;
+        }
+        String digit = matcher.group(1);
+        lines.add("[" + (digit == null ? "" : digit) + "학년]");
+    }
+
+    private void convertTable(KordocBlock block, List<String> lines, List<String> unrecognizedSubjectBlobs) {
+        for (KordocTableRow row : block.rowsOrEmpty()) {
+            List<KordocTableCell> cells = row.cellsOrEmpty();
+            Optional<KordocTableCell> scoreCell = findScoreCell(cells);
+            if (scoreCell.isEmpty()) {
+                convertPassthroughRow(cells, lines);
+                continue;
+            }
+
+            List<String> scoreLines = scoreCell.get().textOrEmpty().lines().map(String::strip)
+                    .filter(line -> !line.isEmpty()).toList();
+
+            Optional<KordocTableCell> subjectCell = findSubjectCell(cells, scoreCell.get());
+            Optional<List<String>> subjects = subjectCell
+                    .flatMap(cell -> subjectTokenizer.tokenize(cell.textOrEmpty(), scoreLines.size()));
+
+            if (subjects.isEmpty()) {
+                subjectCell.ifPresent(cell -> unrecognizedSubjectBlobs.add(cell.textOrEmpty()));
+                continue;
+            }
+
+            findSemesterDigit(cells).ifPresent(lines::add);
+            for (int index = 0; index < subjects.get().size(); index++) {
+                lines.add(subjects.get().get(index) + " " + scoreLines.get(index));
+            }
+        }
+    }
+
+    /** 원점수/성취도 열: 줄마다 "91/77.8 A(168)" 형태를 갖는 셀입니다. */
+    private Optional<KordocTableCell> findScoreCell(List<KordocTableCell> cells) {
+        return cells.stream().filter(cell -> {
+            List<String> lines = cell.textOrEmpty().lines().map(String::strip).filter(line -> !line.isEmpty()).toList();
+            return !lines.isEmpty() && lines.stream().allMatch(line -> SCORE_LINE.matcher(line).matches());
+        }).findFirst();
+    }
+
+    /** 과목명 열: 원점수 셀도, 학기 숫자 하나짜리 셀도 아니면서 한글이 가장 많이 포함된 셀입니다. */
+    private Optional<KordocTableCell> findSubjectCell(List<KordocTableCell> cells, KordocTableCell scoreCell) {
+        return cells.stream().filter(cell -> cell != scoreCell)
+                .filter(cell -> !BARE_SEMESTER.matcher(cell.textOrEmpty().strip()).matches()).max((first,
+                        second) -> Integer.compare(countHangul(first.textOrEmpty()), countHangul(second.textOrEmpty())))
+                .filter(cell -> countHangul(cell.textOrEmpty()) > 0);
+    }
+
+    private Optional<String> findSemesterDigit(List<KordocTableCell> cells) {
+        return cells.stream().map(cell -> cell.textOrEmpty().strip())
+                .filter(text -> BARE_SEMESTER.matcher(text).matches()).findFirst();
+    }
+
+    private int countHangul(String text) {
+        Matcher matcher = HANGUL.matcher(text);
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
+    }
+
+    /** 원점수/성취도 열을 찾지 못한 행(출결 · 봉사 등으로 추정)은 셀을 이어붙여 그대로 지나가는 줄로 남깁니다. */
+    private void convertPassthroughRow(List<KordocTableCell> cells, List<String> lines) {
+        String joined = cells.stream().map(KordocTableCell::textOrEmpty).filter(text -> !text.isBlank())
+                .reduce((a, b) -> a + " " + b).orElse("");
+        if (!joined.isBlank()) {
+            lines.add(joined);
+        }
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
@@ -1,0 +1,103 @@
+package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocParseResult;
+import team.themoment.sdk.exception.ExpectedException;
+
+/**
+ * kordoc(Node.js CLI, {@code @clazic/kordoc})을 subprocess로 실행합니다.
+ *
+ * <p>
+ * 별도 서비스를 두지 않고 {@link ProcessBuilder}로 직접 실행하는 방식(연동 방식 A)입니다. 트래픽이 늘어 프로세스 기동
+ * 오버헤드가 문제가 되면 별도 Node 마이크로서비스(방식 B)로 전환을 검토합니다.
+ *
+ * <p>
+ * <b>검증 한계:</b> 실행 환경에 kordoc이 설치되어 있지 않아 이 클래스는 실제 kordoc 실행으로 검증하지 못했습니다. 배포
+ * 전 실제 Node 환경에서 한 번 실행해 CLI 인자 · 종료 코드 · JSON 출력 형태를 확인해야 합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KordocCliOcrClient implements KordocOcrClient {
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${oneseo.extraction.ocr.process-timeout-seconds:30}")
+    private long processTimeoutSeconds;
+
+    @Override
+    public KordocParseResult recognize(Path imagePath) {
+        Path stdoutFile = null;
+        Path stderrFile = null;
+        try {
+            stdoutFile = Files.createTempFile("kordoc-out-", ".json");
+            stderrFile = Files.createTempFile("kordoc-err-", ".log");
+
+            Process process = new ProcessBuilder("npx", "kordoc", imagePath.toString(), "--format", "json", "--ocr")
+                    .redirectOutput(stdoutFile.toFile()).redirectError(stderrFile.toFile()).start();
+
+            boolean finished = process.waitFor(processTimeoutSeconds, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                throw new ExpectedException("OCR 처리 시간이 너무 오래 걸려 중단했습니다. 다시 시도해주세요.", HttpStatus.GATEWAY_TIMEOUT);
+            }
+            if (process.exitValue() != 0) {
+                log.error("kordoc 실행 실패. exitCode={}, stderr={}", process.exitValue(), readQuietly(stderrFile));
+                throw new ExpectedException("스캔 이미지를 인식하지 못했습니다. 다른 이미지로 시도해주세요.", HttpStatus.UNPROCESSABLE_ENTITY);
+            }
+
+            return parseJson(Files.readString(stdoutFile, StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            log.error("kordoc 프로세스 실행 중 입출력 오류", e);
+            throw new ExpectedException("OCR 엔진을 실행하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ExpectedException("OCR 처리가 중단되었습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        } finally {
+            deleteQuietly(stdoutFile);
+            deleteQuietly(stderrFile);
+        }
+    }
+
+    KordocParseResult parseJson(String json) {
+        try {
+            return objectMapper.readValue(json, KordocParseResult.class);
+        } catch (JsonProcessingException e) {
+            log.error("kordoc 출력 JSON 파싱 실패", e);
+            throw new ExpectedException("OCR 결과를 해석하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String readQuietly(Path file) {
+        try {
+            return Files.readString(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return "";
+        }
+    }
+
+    private void deleteQuietly(Path file) {
+        if (file == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            log.warn("kordoc 임시 파일 삭제 실패. path={}", file);
+        }
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
@@ -1,9 +1,13 @@
 package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -46,9 +50,13 @@ public class KordocCliOcrClient implements KordocOcrClient {
         try {
             stdoutFile = Files.createTempFile("kordoc-out-", ".json");
             stderrFile = Files.createTempFile("kordoc-err-", ".log");
+            restrictToOwner(stdoutFile);
+            restrictToOwner(stderrFile);
 
             Process process = new ProcessBuilder("npx", "kordoc", imagePath.toString(), "--format", "json", "--ocr")
                     .redirectOutput(stdoutFile.toFile()).redirectError(stderrFile.toFile()).start();
+            // 기본 표준 입력(PIPE)을 그대로 두면 kordoc이 입력을 기다릴 때 무한정 블록될 수 있어 즉시 EOF를 보냅니다.
+            closeQuietly(process.getOutputStream());
 
             boolean finished = process.waitFor(processTimeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
@@ -87,6 +95,30 @@ public class KordocCliOcrClient implements KordocOcrClient {
             return Files.readString(file, StandardCharsets.UTF_8);
         } catch (IOException e) {
             return "";
+        }
+    }
+
+    /**
+     * kordoc의 출력에는 생활기록부에서 인식한 실제 내용(개인정보)이 담기므로, 임시 파일을 소유자만 읽고 쓸 수 있게 제한합니다.
+     * POSIX를 지원하지 않는 파일 시스템(로컬 Windows 개발 환경 등)에서는 건너뜁니다.
+     */
+    private void restrictToOwner(Path file) {
+        if (!FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            return;
+        }
+        try {
+            Files.setPosixFilePermissions(file,
+                    Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        } catch (IOException e) {
+            log.warn("kordoc 임시 파일 권한 설정 실패. path={}", file);
+        }
+    }
+
+    private void closeQuietly(OutputStream stream) {
+        try {
+            stream.close();
+        } catch (IOException e) {
+            log.warn("kordoc 표준 입력 스트림 종료 실패");
         }
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocConversionResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocConversionResult.java
@@ -1,0 +1,16 @@
+package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
+
+import java.util.List;
+
+/**
+ * kordoc 표 재구성 결과를
+ * {@link team.themoment.hellogsmv3.domain.oneseo.service.extraction.MiddleSchoolRecordParser}가
+ * 읽는 줄 형식으로 바꾼 결과입니다.
+ *
+ * @param rawText
+ *            변환된 줄들을 개행으로 이어붙인 텍스트
+ * @param unrecognizedSubjectBlobs
+ *            표준 과목 9개만으로 분해하지 못해 건너뛴 과목명 원문. 사용자 검수가 필요합니다.
+ */
+public record KordocConversionResult(String rawText, List<String> unrecognizedSubjectBlobs) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocOcrClient.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocOcrClient.java
@@ -1,0 +1,11 @@
+package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
+
+import java.nio.file.Path;
+
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocParseResult;
+
+/** kordoc으로 스캔 이미지 한 장을 인식해 표 재구성 결과를 얻습니다. */
+public interface KordocOcrClient {
+
+    KordocParseResult recognize(Path imagePath);
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizer.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizer.java
@@ -1,0 +1,81 @@
+package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.SubjectNameNormalizer;
+
+/**
+ * kordoc이 표를 재구성할 때 과목명 열이 구분자 없이 붙어서 나오는 문제를 해결합니다. 예:
+ * {@code "국어역사수학과학기술가정정보영어"} → {@code [국어, 역사, 수학, 과학, 기술가정, 정보, 영어]}.
+ *
+ * <p>
+ * 표준 과목 9개({@link SubjectNameNormalizer#STANDARD_GENERAL_SUBJECTS})만으로 문자열 전체를
+ * 빈틈없이 분해할 수 있을 때만 성공으로 봅니다. 선택 과목처럼 사전에 없는 과목명이 섞여 있으면 어디서 잘라야 할지 알 수 없으므로,
+ * 억지로 나누지 않고 실패를 반환해 호출자가 검수 대상으로 표시하게 합니다.
+ */
+@Component
+public class KordocSubjectTokenizer {
+
+    private static final List<String> DICTIONARY_BY_LENGTH_DESC = SubjectNameNormalizer.STANDARD_GENERAL_SUBJECTS
+            .stream().sorted(Comparator.comparingInt(String::length).reversed()).toList();
+
+    /**
+     * @param subjectBlob
+     *            구분자 없이 붙어 있는 과목명 문자열
+     * @param expectedCount
+     *            같은 행의 원점수/성취도 셀을 줄바꿈으로 나눈 개수. 실제 과목 수의 근거입니다.
+     * @return 분해된 과목명 목록. 표준 과목만으로 전체를 나누지 못했거나 개수가 맞지 않으면 빈 값입니다.
+     */
+    public Optional<List<String>> tokenize(String subjectBlob, int expectedCount) {
+        String normalized = stripDecorations(subjectBlob);
+        if (normalized.isEmpty() || expectedCount <= 0) {
+            return Optional.empty();
+        }
+
+        List<String> tokens = segment(normalized, 0, new HashMap<>());
+        if (tokens == null || tokens.size() != expectedCount) {
+            return Optional.empty();
+        }
+        return Optional.of(tokens);
+    }
+
+    private String stripDecorations(String raw) {
+        if (raw == null) {
+            return "";
+        }
+        return raw.replaceAll("[\\s·・ㆍ/,~-]", "").strip();
+    }
+
+    /** 표준 과목 사전으로 문자열 전체를 빈틈없이 나누는 하나의 경로를 찾습니다. 매 위치에서 가장 긴 과목명을 먼저 시도합니다. */
+    private List<String> segment(String text, int start, Map<Integer, List<String>> memo) {
+        if (start == text.length()) {
+            return new ArrayList<>();
+        }
+        if (memo.containsKey(start)) {
+            return memo.get(start);
+        }
+
+        for (String subject : DICTIONARY_BY_LENGTH_DESC) {
+            if (text.startsWith(subject, start)) {
+                List<String> rest = segment(text, start + subject.length(), memo);
+                if (rest != null) {
+                    List<String> result = new ArrayList<>();
+                    result.add(subject);
+                    result.addAll(rest);
+                    memo.put(start, result);
+                    return result;
+                }
+            }
+        }
+
+        memo.put(start, null);
+        return null;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizer.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizer.java
@@ -62,6 +62,8 @@ public class KordocSubjectTokenizer {
             return memo.get(start);
         }
 
+        // 가장 긴 과목명부터 시도하되, 그 뒤가 막히면(rest == null) 되돌아가 다음 후보를 시도합니다(백트래킹).
+        // 표준 과목 9개는 서로 접두사 관계가 없어 실제로는 되돌아갈 일이 없지만, 사전이 바뀌어도 안전하도록 남겨둡니다.
         for (String subject : DICTIONARY_BY_LENGTH_DESC) {
             if (text.startsWith(subject, start)) {
                 List<String> rest = segment(text, start + subject.length(), memo);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizer.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizer.java
@@ -46,11 +46,17 @@ public class KordocSubjectTokenizer {
         return Optional.of(tokens);
     }
 
+    /**
+     * 공백 · 중점 등 표기 장식과 함께, "사회(역사포함)"처럼 과목명에 덧붙는 괄호 설명도 제거합니다. 괄호를 남겨두면 그 과목 하나만이
+     * 아니라 사전 매칭이 막힌 지점부터 행 전체의 분해가 실패합니다.
+     * {@link team.themoment.hellogsmv3.domain.oneseo.service.extraction.SubjectNameNormalizer#normalize}가
+     * 개별 과목명에 대해 하는 것과 같은 처리입니다.
+     */
     private String stripDecorations(String raw) {
         if (raw == null) {
             return "";
         }
-        return raw.replaceAll("[\\s·・ㆍ/,~-]", "").strip();
+        return raw.replaceAll("\\([^)]*\\)", "").replaceAll("[\\s·・ㆍ/,~-]", "").strip();
     }
 
     /** 표준 과목 사전으로 문자열 전체를 빈틈없이 나누는 하나의 경로를 찾습니다. 매 위치에서 가장 긴 과목명을 먼저 시도합니다. */

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/OcrConcurrencyGate.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/OcrConcurrencyGate.java
@@ -1,0 +1,50 @@
+package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import team.themoment.sdk.exception.ExpectedException;
+
+/**
+ * kordoc subprocess 동시 실행 개수를 제한합니다.
+ *
+ * <p>
+ * kordoc은 페이지당 약 1초의 CPU를 씁니다. 원서 접수 마감 직전처럼 요청이 몰리면 프로세스가 무제한으로 늘어날 수 있어, 초과분은
+ * 큐잉 대신 즉시 재시도를 요청합니다.
+ */
+@Component
+public class OcrConcurrencyGate {
+
+    private final Semaphore semaphore;
+    private final long acquireTimeoutSeconds;
+
+    public OcrConcurrencyGate(@Value("${oneseo.extraction.ocr.max-concurrent-jobs:2}") int maxConcurrentJobs,
+            @Value("${oneseo.extraction.ocr.acquire-timeout-seconds:5}") long acquireTimeoutSeconds) {
+        this.semaphore = new Semaphore(maxConcurrentJobs);
+        this.acquireTimeoutSeconds = acquireTimeoutSeconds;
+    }
+
+    public <T> T runWithinLimit(Supplier<T> action) {
+        boolean acquired;
+        try {
+            acquired = semaphore.tryAcquire(acquireTimeoutSeconds, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ExpectedException("OCR 처리 대기가 중단되었습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        if (!acquired) {
+            throw new ExpectedException("OCR 처리가 지금 많이 몰려 있습니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE);
+        }
+
+        try {
+            return action.get();
+        } finally {
+            semaphore.release();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,8 +74,9 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 5MB
-      max-request-size: 5MB
+      # 생기부 스캔 페이지 이미지 업로드(OCR)를 수용하기 위해 5MB에서 상향
+      max-file-size: 10MB
+      max-request-size: 10MB
     encoding:
       charset: UTF-8
       enabled: true
@@ -91,6 +92,13 @@ oneseo:
     # 데모 진단용. 전달받은 생활기록부 원문을 응답에 되돌려줍니다.
     # 개인정보가 그대로 노출되므로 운영 환경에서는 반드시 false여야 합니다.
     expose-raw-text: ${EXTRACTION_EXPOSE_RAW_TEXT:false}
+    ocr:
+      # kordoc subprocess 동시 실행 최대 개수. 트래픽이 늘면 조정하고, 필요하면 방식 B(별도 마이크로서비스)로 전환합니다.
+      max-concurrent-jobs: ${EXTRACTION_OCR_MAX_CONCURRENT_JOBS:2}
+      # 동시 실행 한도가 찼을 때 자리가 날 때까지 기다리는 시간
+      acquire-timeout-seconds: ${EXTRACTION_OCR_ACQUIRE_TIMEOUT_SECONDS:5}
+      # kordoc 프로세스 자체의 실행 제한 시간
+      process-timeout-seconds: ${EXTRACTION_OCR_PROCESS_TIMEOUT_SECONDS:30}
 schedule:
   oneseoSubmissionStart: ${ONESEO_SUBMISSION_START}
   oneseoSubmissionEnd: ${ONESEO_SUBMISSION_END}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextServiceTest.java
@@ -1,0 +1,115 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocParseResult;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrPageTextResDto;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr.KordocAchievementTextConverter;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr.KordocConversionResult;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr.KordocOcrClient;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr.OcrConcurrencyGate;
+import team.themoment.sdk.exception.ExpectedException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OCR 페이지 텍스트 추출 서비스 테스트")
+class ExtractOcrPageTextServiceTest {
+
+    @Mock
+    private KordocOcrClient kordocOcrClient;
+
+    @Mock
+    private KordocAchievementTextConverter converter;
+
+    private ExtractOcrPageTextService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ExtractOcrPageTextService(kordocOcrClient, converter, new OcrConcurrencyGate(1, 5));
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("파일이 존재하지 않는 경우")
+        class Context_with_empty_file {
+
+            @Test
+            @DisplayName("ExpectedException을 던지고 OCR을 실행하지 않는다")
+            void it_throws_expected_exception() {
+                MultipartFile emptyFile = new MockMultipartFile("file", "", "image/jpeg", new byte[0]);
+
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> service.execute(emptyFile));
+
+                assertThat(exception.getMessage()).isEqualTo("파일이 존재하지 않습니다.");
+                assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                verify(kordocOcrClient, never()).recognize(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("지원하지 않는 확장자가 주어진 경우")
+        class Context_with_invalid_extension {
+
+            @Test
+            @DisplayName("ExpectedException을 던지고 OCR을 실행하지 않는다")
+            void it_throws_expected_exception() {
+                MultipartFile file = new MockMultipartFile("file", "page.pdf", "application/pdf", "data".getBytes());
+
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> service.execute(file));
+
+                assertThat(exception.getMessage()).isEqualTo("지원하지 않는 파일 확장자입니다.");
+                assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                verify(kordocOcrClient, never()).recognize(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("유효한 스캔 이미지가 주어진 경우")
+        class Context_with_valid_image {
+
+            @Test
+            @DisplayName("변환 결과를 반환하고 임시 이미지 파일을 삭제한다")
+            void it_returns_conversion_result_and_deletes_temp_file() {
+                MultipartFile file = new MockMultipartFile("file", "page.jpg", "image/jpeg", "fake-image".getBytes());
+                KordocParseResult parseResult = new KordocParseResult(List.of());
+                KordocConversionResult conversionResult = new KordocConversionResult("[1학년]\n국어 91/77.8 A(168)",
+                        List.of());
+
+                given(kordocOcrClient.recognize(any())).willReturn(parseResult);
+                given(converter.convert(parseResult)).willReturn(conversionResult);
+
+                OcrPageTextResDto result = service.execute(file);
+
+                assertThat(result.rawText()).isEqualTo(conversionResult.rawText());
+                assertThat(result.unrecognizedSubjectBlobs()).isEmpty();
+
+                ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
+                verify(kordocOcrClient).recognize(pathCaptor.capture());
+                assertThat(Files.exists(pathCaptor.getValue())).isFalse();
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverterTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverterTest.java
@@ -1,0 +1,115 @@
+package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.ExtractedTextDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.ExtractionSource;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocBlock;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocParseResult;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocTableCell;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocTableRow;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.ExtractedAchievementResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.MiddleSchoolRecordParser;
+import team.themoment.hellogsmv3.domain.oneseo.service.extraction.SubjectNameNormalizer;
+
+/**
+ * 합성(synthetic) kordoc JSON 형태로 검증합니다. 실제 kordoc이 이 환경에 설치되어 있지 않아 실제 출력으로는
+ * 검증하지 못했습니다 — 실제 kordoc 환경에서 RecordExtractionDiagnosticTest로 별도 검증이 필요합니다.
+ */
+@DisplayName("kordoc 표 재구성 결과 변환 테스트")
+class KordocAchievementTextConverterTest {
+
+    private KordocAchievementTextConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new KordocAchievementTextConverter(new KordocSubjectTokenizer());
+    }
+
+    @Nested
+    @DisplayName("convert 메서드는")
+    class Describe_convert {
+
+        @Nested
+        @DisplayName("학년 제목과 과목명이 붙어있는 성적 표가 주어진 경우")
+        class Context_with_grade_heading_and_merged_subject_table {
+
+            @Test
+            @DisplayName("기존 파서가 읽을 수 있는 rawText로 변환한다")
+            void it_converts_to_parser_readable_text() {
+                KordocBlock heading = new KordocBlock("heading", "1학년", null, 1);
+
+                KordocTableCell semesterCell = new KordocTableCell("2", 1, 1);
+                KordocTableCell subjectCell = new KordocTableCell("국어사회도덕역사수학과학기술가정정보영어", 1, 1);
+                KordocTableCell scoreCell = new KordocTableCell(String.join("\n",
+                        "91/77.8 A(168)",
+                        "88/70.2 B(168)",
+                        "75/65.0 C(168)",
+                        "60/64.0 D(168)",
+                        "95/71.0 A(168)",
+                        "85/69.0 B(168)",
+                        "78/68.0 C(168)",
+                        "65/64.0 D(168)",
+                        "90/72.0 A(168)"), 1, 1);
+                KordocTableRow row = new KordocTableRow(List.of(semesterCell, subjectCell, scoreCell));
+                KordocBlock table = new KordocBlock("table", null, List.of(row), 1);
+
+                KordocParseResult parseResult = new KordocParseResult(List.of(heading, table));
+
+                KordocConversionResult conversion = converter.convert(parseResult);
+                assertThat(conversion.unrecognizedSubjectBlobs()).isEmpty();
+
+                ExtractedAchievementResDto result = new MiddleSchoolRecordParser(new SubjectNameNormalizer()).parse(
+                        new ExtractedTextDto(conversion.rawText(), 1, false, ExtractionSource.OCR, 0.8),
+                        GraduationType.GRADUATE,
+                        null);
+
+                assertThat(result.achievement().achievement1_2()).containsExactly(5, 4, 3, 2, 5, 4, 3, 2, 5);
+            }
+        }
+
+        @Nested
+        @DisplayName("과목명 열이 표준 과목 사전만으로 분해되지 않는 경우")
+        class Context_with_unsegmentable_subject_blob {
+
+            @Test
+            @DisplayName("그 행을 건너뛰고 원문을 unrecognizedSubjectBlobs로 돌려준다")
+            void it_skips_row_and_reports_blob() {
+                KordocTableCell subjectCell = new KordocTableCell("국어한문수학", 1, 1);
+                KordocTableCell scoreCell = new KordocTableCell(String
+                        .join("\n", "91/77.8 A(168)", "88/70.2 B(168)", "75/65.0 C(168)"), 1, 1);
+                KordocTableRow row = new KordocTableRow(List.of(subjectCell, scoreCell));
+                KordocBlock table = new KordocBlock("table", null, List.of(row), 1);
+
+                KordocConversionResult conversion = converter.convert(new KordocParseResult(List.of(table)));
+
+                assertThat(conversion.unrecognizedSubjectBlobs()).containsExactly("국어한문수학");
+            }
+        }
+
+        @Nested
+        @DisplayName("원점수/성취도 열을 찾을 수 없는 행(출결 등으로 추정)이 주어진 경우")
+        class Context_with_non_achievement_row {
+
+            @Test
+            @DisplayName("셀을 그대로 이어붙인 줄로 지나간다")
+            void it_passes_through_joined_cells() {
+                KordocTableRow row = new KordocTableRow(
+                        List.of(new KordocTableCell("1", 1, 1), new KordocTableCell("190", 1, 1)));
+                KordocBlock table = new KordocBlock("table", null, List.of(row), 1);
+
+                KordocConversionResult conversion = converter.convert(new KordocParseResult(List.of(table)));
+
+                assertThat(conversion.rawText()).contains("1 190");
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverterTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverterTest.java
@@ -111,5 +111,21 @@ class KordocAchievementTextConverterTest {
                 assertThat(conversion.rawText()).contains("1 190");
             }
         }
+
+        @Nested
+        @DisplayName("학년을 언급할 뿐인 제목 블록이 주어진 경우")
+        class Context_with_heading_merely_mentioning_grade {
+
+            @Test
+            @DisplayName("학년 표시로 오인하지 않는다")
+            void it_does_not_misread_as_grade_marker() {
+                KordocBlock title = new KordocBlock("heading", "2024학년도 생활기록부", null, 1);
+                KordocBlock caption = new KordocBlock("text", "학년별 출결현황", null, 1);
+
+                KordocConversionResult conversion = converter.convert(new KordocParseResult(List.of(title, caption)));
+
+                assertThat(conversion.rawText()).doesNotContain("[").doesNotContain("학년]");
+            }
+        }
     }
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizerTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizerTest.java
@@ -1,0 +1,92 @@
+package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("kordoc 과목명 토큰 분리 테스트")
+class KordocSubjectTokenizerTest {
+
+    private KordocSubjectTokenizer tokenizer;
+
+    @BeforeEach
+    void setUp() {
+        tokenizer = new KordocSubjectTokenizer();
+    }
+
+    @Nested
+    @DisplayName("tokenize 메서드는")
+    class Describe_tokenize {
+
+        @Nested
+        @DisplayName("표준 과목 9개로만 이루어진 문자열이 주어진 경우")
+        class Context_with_all_standard_subjects {
+
+            @Test
+            @DisplayName("순서대로 분리한다")
+            void it_splits_in_order() {
+                Optional<List<String>> result = tokenizer.tokenize("국어사회도덕역사수학과학기술가정정보영어", 9);
+
+                assertThat(result).isPresent();
+                assertThat(result.get()).containsExactly("국어", "사회", "도덕", "역사", "수학", "과학", "기술가정", "정보", "영어");
+            }
+        }
+
+        @Nested
+        @DisplayName("표준 과목 일부만 있는 경우")
+        class Context_with_subset_of_standard_subjects {
+
+            @Test
+            @DisplayName("있는 만큼만 순서대로 분리한다")
+            void it_splits_subset() {
+                Optional<List<String>> result = tokenizer.tokenize("사회수학영어", 3);
+
+                assertThat(result).isPresent();
+                assertThat(result.get()).containsExactly("사회", "수학", "영어");
+            }
+        }
+
+        @Nested
+        @DisplayName("사전에 없는 과목명(선택 과목 등)이 섞여 있는 경우")
+        class Context_with_unknown_subject {
+
+            @Test
+            @DisplayName("빈 값을 반환한다")
+            void it_returns_empty() {
+                Optional<List<String>> result = tokenizer.tokenize("국어한문수학", 3);
+
+                assertThat(result).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("분리된 개수가 기대 개수와 다른 경우")
+        class Context_with_count_mismatch {
+
+            @Test
+            @DisplayName("빈 값을 반환한다")
+            void it_returns_empty() {
+                Optional<List<String>> result = tokenizer.tokenize("국어사회도덕", 2);
+
+                assertThat(result).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("빈 문자열이 주어진 경우")
+        class Context_with_blank_input {
+
+            @Test
+            @DisplayName("빈 값을 반환한다")
+            void it_returns_empty() {
+                assertThat(tokenizer.tokenize("   ", 1)).isEmpty();
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizerTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocSubjectTokenizerTest.java
@@ -53,6 +53,20 @@ class KordocSubjectTokenizerTest {
         }
 
         @Nested
+        @DisplayName("과목명에 괄호 설명이 붙어 있는 경우")
+        class Context_with_parenthetical_annotation {
+
+            @Test
+            @DisplayName("괄호 내용을 제거하고 분리한다")
+            void it_strips_parenthetical_annotation() {
+                Optional<List<String>> result = tokenizer.tokenize("국어사회(역사포함)도덕", 3);
+
+                assertThat(result).isPresent();
+                assertThat(result.get()).containsExactly("국어", "사회", "도덕");
+            }
+        }
+
+        @Nested
         @DisplayName("사전에 없는 과목명(선택 과목 등)이 섞여 있는 경우")
         class Context_with_unknown_subject {
 


### PR DESCRIPTION
## 배경
생기부 OCR 정확도 개선 스펙의 작업 2(kordoc을 서버 OCR 엔진으로 통합)와 작업 3(kordoc 출력 → 파서 입력 변환)입니다. 작업 1(로깅)은 PR #402로 이미 머지되었습니다.

확정된 결정:
- 연동 방식: 방식 A — Java `ProcessBuilder`로 kordoc CLI subprocess 실행
- 이미지 처리 주체: 서버로 스캔 이미지 전송 + kordoc 처리 (클라이언트 Tesseract.js 대체)

## 변경 사항

### 작업 2 — kordoc 서버 통합
- `POST /oneseo/v3/extraction/middle-school-achievement/ocr-page` 신설 (multipart 이미지 업로드 → rawText 조각 반환)
- `KordocCliOcrClient`: `npx kordoc <이미지> --format json --ocr` subprocess 실행. stdout/stderr는 임시파일로 리다이렉트해 파이프 데드락을 피했고, 타임아웃 시 프로세스를 강제 종료합니다.
- `OcrConcurrencyGate`: `Semaphore` 기반 동시 실행 제한(기본 2개). 초과 시 503으로 즉시 재시도를 요청합니다(큐잉 대신).
- 업로드된 이미지는 처리 직후(finally) 항상 삭제되며 서버에 영구 저장되지 않습니다.
- `application.yml`에 `oneseo.extraction.ocr.*` 설정 추가, multipart 상한 5MB → 10MB.
- `DockerfileProd`/`DockerfileStage`에 Node.js 멀티스테이지를 추가해 `npx kordoc`이 컨테이너에서 실행되도록 했습니다.

### 작업 3 — kordoc 출력 → 파서 입력 변환
- `KordocSubjectTokenizer`: 붙어있는 과목명 문자열을 기존 표준 과목 9개 사전(`SubjectNameNormalizer`)만으로 word-break 방식 분해합니다. 사전에 없는 과목이 섞여 분해가 안 되면 억지로 나누지 않고 실패를 반환해 검수 대상으로 표시합니다.
- `KordocAchievementTextConverter`: kordoc의 표/제목 블록을 기존 `MiddleSchoolRecordParser`가 읽는 rawText 줄 형식(`[N학년]`, 학기 단독 줄, `과목 원점수/평균 성취도`)으로 되돌립니다. **새 파서를 만들지 않고 이미 실제 생활기록부로 검증된 기존 파서를 그대로 재사용**하는 것이 핵심입니다.

## 검증 한계 (반드시 확인 필요)
이 작업을 진행한 환경에 kordoc이 설치되어 있지 않아 **실제 kordoc 실행으로는 검증하지 못했습니다.** 웹 공식 문서의 JSON 포맷을 근거로 구현·테스트했으며, 아래는 실제 Node+kordoc 환경에서 진짜 스캔 이미지로 검증이 필요합니다.
1. `KordocCliOcrClient`의 CLI 인자(`--format json --ocr`)와 종료 코드 처리
2. `KordocAchievementTextConverter`가 가정한 표 셀 배치(학기/과목명/원점수 셀 구분 방식)
3. Dockerfile의 OCR 모델(~18MB) 캐시 워밍업 — 정확한 캐시 경로를 확인하지 못해 이번엔 보류했고 TODO로 남겨두었습니다. 그 전까지는 컨테이너의 첫 OCR 요청에서 모델 다운로드 네트워크 호출이 한 번 발생합니다.

## 테스트
- `KordocSubjectTokenizerTest`, `KordocAchievementTextConverterTest`(합성 데이터를 기존 `MiddleSchoolRecordParser`에 실제로 통과시켜 검증), `ExtractOcrPageTextServiceTest` 신규 추가
- 전체 `./gradlew test` 통과, `./gradlew spotlessApply` 적용
- 실제 생기부 원문은 저장소에 커밋하지 않음(PR #399/#402와 동일한 방침)