### PR TITLE
[oneseo] 자유학기제 졸업자 생기부 추출 시 1학년 성적 반영

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/ExtractMiddleSchoolAchievementReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/ExtractMiddleSchoolAchievementReqDto.java
@@ -30,6 +30,6 @@ public record ExtractMiddleSchoolAchievementReqDto(
 
         @Schema(description = "졸업 구분. 졸업예정자는 3학년 2학기 성적이 없습니다.") @NotNull GraduationType graduationType,
 
-        @Schema(description = "자유학기제 또는 자유학년제. 예체능 성취점수 배열의 길이를 결정하므로 졸업예정자는 필수입니다.", allowableValues = {
+        @Schema(description = "자유학기제 또는 자유학년제. 예체능 성취점수 배열의 길이를 결정하므로 졸업예정자와 졸업자 모두 필수입니다.", allowableValues = {
                 "자유학기제", "자유학년제"}, nullable = true) String liberalSystem){
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
@@ -123,8 +123,12 @@ public class MiddleSchoolRecordParser {
     public static final String FREE_YEAR_SYSTEM = "자유학년제";
     public static final String FREE_SEMESTER_SYSTEM = "자유학기제";
 
-    /** 졸업자가 입력하는 학기. 프론트엔드 {@code artPhysicalGraduationArray}와 일치합니다. */
+    /** 자유학년제 졸업자가 입력하는 학기. 프론트엔드 {@code artPhysicalGraduationArray}와 일치합니다. */
     private static final List<String> GRADUATE_SEMESTERS = List.of("2-1", "2-2", "3-1", "3-2");
+
+    /** 자유학기제 졸업자가 입력하는 학기. 1학년 전체를 포함한 전 학년입니다. */
+    private static final List<String> GRADUATE_FREE_SEMESTER_SEMESTERS = List
+            .of("1-1", "1-2", "2-1", "2-2", "3-1", "3-2");
 
     /** 자유학년제 졸업예정자가 입력하는 학기. 1학년 전체가 제외됩니다. */
     private static final List<String> CANDIDATE_FREE_YEAR_SEMESTERS = List.of("2-1", "2-2", "3-1");
@@ -141,7 +145,7 @@ public class MiddleSchoolRecordParser {
      * @param graduationType
      *            졸업 구분
      * @param liberalSystem
-     *            자유학기제 또는 자유학년제. 예체능 배열의 길이를 결정하므로 졸업예정자에게는 필수입니다.
+     *            자유학기제 또는 자유학년제. 예체능 배열의 길이를 결정하므로 졸업예정자와 졸업자 모두에게 필수입니다.
      */
     public ExtractedAchievementResDto parse(ExtractedTextDto extractedText,
             GraduationType graduationType,
@@ -191,12 +195,11 @@ public class MiddleSchoolRecordParser {
      * 프론트엔드의 {@code artPhysicalGraduationArray} 등과 일치해야 합니다.
      */
     private List<String> resolveSemesters(GraduationType graduationType, String liberalSystem) {
+        boolean isFreeSemester = FREE_SEMESTER_SYSTEM.equals(liberalSystem);
         if (graduationType == GraduationType.GRADUATE) {
-            return GRADUATE_SEMESTERS;
+            return isFreeSemester ? GRADUATE_FREE_SEMESTER_SEMESTERS : GRADUATE_SEMESTERS;
         }
-        return FREE_SEMESTER_SYSTEM.equals(liberalSystem)
-                ? CANDIDATE_FREE_SEMESTER_SEMESTERS
-                : CANDIDATE_FREE_YEAR_SEMESTERS;
+        return isFreeSemester ? CANDIDATE_FREE_SEMESTER_SEMESTERS : CANDIDATE_FREE_YEAR_SEMESTERS;
     }
 
     private void readLines(String rawText, ParseContext context) {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
@@ -376,8 +376,8 @@ class MiddleSchoolRecordParserTest {
         }
 
         @Nested
-        @DisplayName("졸업자의 생활기록부가 주어진 경우")
-        class Context_with_graduate {
+        @DisplayName("자유학년제 졸업자의 생활기록부가 주어진 경우")
+        class Context_with_free_year_graduate {
 
             private ExtractedAchievementResDto result;
 
@@ -397,6 +397,35 @@ class MiddleSchoolRecordParserTest {
             @DisplayName("찾지 못한 3학년 2학기를 누락 학기로 보고한다")
             void it_reports_missing_semester() {
                 assertThat(result.meta().missingSemesters()).containsExactly("3-2");
+                assertThat(result.meta().warnings())
+                        .anyMatch(warning -> warning.type() == ExtractionWarningType.MISSING_SEMESTER);
+            }
+        }
+
+        @Nested
+        @DisplayName("자유학기제 졸업자의 생활기록부가 주어진 경우")
+        class Context_with_free_semester_graduate {
+
+            private ExtractedAchievementResDto result;
+
+            @BeforeEach
+            void setUp() {
+                result = parseSample(GraduationType.GRADUATE, MiddleSchoolRecordParser.FREE_SEMESTER_SYSTEM);
+            }
+
+            @Test
+            @DisplayName("1학년을 포함한 6개 학기 분량의 예체능 배열을 반환한다")
+            void it_returns_six_semesters_of_arts_physical() {
+                // 학기: 1-1, 1-2, 2-1, 2-2, 3-1, 3-2 → 6 * 3 = 18
+                assertThat(result.achievement().artsPhysicalAchievement()).hasSize(18);
+                // 1-2의 체육 A가 두 번째 학기 블록의 첫 칸에 들어간다
+                assertThat(result.achievement().artsPhysicalAchievement().get(3)).isEqualTo(5);
+            }
+
+            @Test
+            @DisplayName("찾지 못한 1학년 1학기와 3학년 2학기를 누락 학기로 보고한다")
+            void it_reports_missing_semesters() {
+                assertThat(result.meta().missingSemesters()).containsExactly("1-1", "3-2");
                 assertThat(result.meta().warnings())
                         .anyMatch(warning -> warning.type() == ExtractionWarningType.MISSING_SEMESTER);
             }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
@@ -420,6 +420,9 @@ class MiddleSchoolRecordParserTest {
                 assertThat(result.achievement().artsPhysicalAchievement()).hasSize(18);
                 // 1-2의 체육 A가 두 번째 학기 블록의 첫 칸에 들어간다
                 assertThat(result.achievement().artsPhysicalAchievement().get(3)).isEqualTo(5);
+                // 예체능 성적을 찾지 못한 과목은 0으로 채워진다 (1-1·2-2·3-2 전체 누락 9칸 + 1-2·3-1의 음악·미술 누락 4칸)
+                assertThat(result.achievement().artsPhysicalAchievement().stream().filter(score -> score == 0))
+                        .hasSize(13);
             }
 
             @Test


### PR DESCRIPTION
## 개요

생기부 자동추출 시 졸업자(GRADUATE)에게 1학년 성적이 반영되지 않던 문제를 수정했습니다. 자유학기제 졸업자도 재학생과 동일하게 1학년 성적이 추출·반영되도록 했습니다.

## 본문

`MiddleSchoolRecordParser.resolveSemesters()`가 재학생(CANDIDATE)에 대해서는 `liberalSystem`(자유학기제/자유학년제)에 따라 대상 학기를 분기했지만, 졸업자(GRADUATE)는 이 값을 전혀 보지 않고 무조건 2·3학년 4개 학기(`2-1, 2-2, 3-1, 3-2`)로 고정되어 있었습니다.

그 결과 자유학기제로 1학년 실제 성적이 존재하는 졸업자도 다음이 모두 스킵되고 있었습니다.
- 1학년 누락 학기 경고(`missingSemesters`)가 절대 발생하지 않음
- 1학년 예체능 성취도가 결과 배열에서 통째로 빠짐
- 신뢰도 계산도 4개 학기 기준으로만 수행됨

### 변경

- `MiddleSchoolRecordParser`에 자유학기제 졸업자용 대상 학기 상수 `GRADUATE_FREE_SEMESTER_SEMESTERS`(1-1~3-2 전체 6개 학기)를 추가하고, `resolveSemesters()`가 졸업자도 재학생과 동일하게 `liberalSystem`을 반영하도록 수정
- `ExtractMiddleSchoolAchievementReqDto`의 `liberalSystem` 필드 설명을 "졸업예정자만 필수" → "졸업예정자·졸업자 모두 필수"로 수정
- `MiddleSchoolRecordParserTest`에 자유학기제 졸업자 케이스(`Context_with_free_semester_graduate`)를 추가하고, 기존 졸업자 테스트를 `Context_with_free_year_graduate`로 명확화

## 관련 이슈
