### PR TITLE
[oneseo] kordoc OCR ObjectMapper 주입 실패로 인한 앱 기동 실패 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
@@ -14,13 +14,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocParseResult;
 import team.themoment.sdk.exception.ExpectedException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * kordoc(Node.js CLI, {@code @clazic/kordoc})을 subprocess로 실행합니다.
@@ -90,7 +89,7 @@ public class KordocCliOcrClient implements KordocOcrClient {
     KordocParseResult parseJson(String json) {
         try {
             return objectMapper.readValue(json, KordocParseResult.class);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             log.error("kordoc 출력 JSON 파싱 실패", e);
             throw new ExpectedException("OCR 결과를 해석하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClientTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClientTest.java
@@ -1,0 +1,104 @@
+package team.themoment.hellogsmv3.domain.oneseo.service.extraction.ocr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.kordoc.KordocParseResult;
+import team.themoment.sdk.exception.ExpectedException;
+import tools.jackson.databind.ObjectMapper;
+
+@DisplayName("kordoc CLI OCR 클라이언트 테스트")
+class KordocCliOcrClientTest {
+
+    private KordocCliOcrClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = new KordocCliOcrClient(new ObjectMapper());
+    }
+
+    @Nested
+    @DisplayName("parseJson 메서드는")
+    class Describe_parseJson {
+
+        @Nested
+        @DisplayName("kordoc이 출력하는 형식의 JSON이 주어진 경우")
+        class Context_with_valid_kordoc_json {
+
+            private static final String JSON = """
+                    {
+                      "blocks": [
+                        {
+                          "type": "heading",
+                          "text": "1학년",
+                          "pageNumber": 1
+                        },
+                        {
+                          "type": "table",
+                          "pageNumber": 1,
+                          "table": {
+                            "cells": [
+                              [
+                                {"text": "국어", "colSpan": 1, "rowSpan": 1},
+                                {"text": "A", "colSpan": 1, "rowSpan": 1}
+                              ]
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                    """;
+
+            @Test
+            @DisplayName("블록과 표를 KordocParseResult로 역직렬화한다")
+            void it_deserializes_into_kordoc_parse_result() {
+                KordocParseResult result = client.parseJson(JSON);
+
+                assertThat(result.blocksOrEmpty()).hasSize(2);
+                assertThat(result.blocksOrEmpty().get(0).textOrEmpty()).isEqualTo("1학년");
+                assertThat(result.blocksOrEmpty().get(1).isTable()).isTrue();
+                assertThat(result.blocksOrEmpty().get(1).tableRowsOrEmpty().get(0).get(0).textOrEmpty())
+                        .isEqualTo("국어");
+            }
+        }
+
+        @Nested
+        @DisplayName("알 수 없는 필드가 섞인 JSON이 주어진 경우")
+        class Context_with_unknown_fields {
+
+            @Test
+            @DisplayName("알 수 없는 필드는 무시하고 역직렬화한다")
+            void it_ignores_unknown_fields() {
+                String json = """
+                        {
+                          "blocks": [
+                            {"type": "text", "text": "안내문", "pageNumber": 1, "confidence": 0.9}
+                          ],
+                          "meta": {"engine": "kordoc"}
+                        }
+                        """;
+
+                KordocParseResult result = client.parseJson(json);
+
+                assertThat(result.blocksOrEmpty()).hasSize(1);
+                assertThat(result.blocksOrEmpty().get(0).textOrEmpty()).isEqualTo("안내문");
+            }
+        }
+
+        @Nested
+        @DisplayName("깨진 JSON이 주어진 경우")
+        class Context_with_malformed_json {
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                assertThatThrownBy(() -> client.parseJson("{ not-json")).isInstanceOf(ExpectedException.class);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

스테이지 배포가 계속 실패하던 원인을 찾아 수정했습니다. kordoc OCR 클라이언트가 Spring이 자동으로 만들어주지 않는 구버전 Jackson `ObjectMapper`를 주입받고 있어 애플리케이션 기동 자체가 실패하고 있었습니다.

## 본문

`develop` push마다 CD가 실패하고 있었습니다 (Actions run [32578000819](https://github.com/themoment-team/hellogsm-server-26/actions/runs/32578000819) 등). 원인을 추적한 결과:

1. CodeDeploy가 `DeploymentLimitExceededException`으로 즉시 실패 — 배포 그룹에 이미 활성 배포가 있었음
2. 그 활성 배포는 ALB 타겟 그룹에 1시간 동안 healthy 등록을 못 해 타임아웃으로 실패
3. 스테이지 CloudWatch 로그(`hellogsm-stage-log`) 확인 결과, **애플리케이션이 아예 기동에 실패**하고 있었음:
   ```
   APPLICATION FAILED TO START
   Parameter 0 of constructor in ...KordocCliOcrClient required a bean of
   type 'com.fasterxml.jackson.databind.ObjectMapper' that could not be found.
   ```

Spring Boot 4는 기본 JSON 바인딩이 Jackson 3(`tools.jackson.databind`)으로 전환되어, `spring-boot-starter-jackson`이 자동구성하는 `ObjectMapper` 빈도 `tools.jackson.databind.ObjectMapper` 하나뿐입니다. 반면 `KordocCliOcrClient`는 생성자로 구버전 `com.fasterxml.jackson.databind.ObjectMapper`를 요구하고 있었는데, 이 타입은 클래스패스엔 있어도(다른 라이브러리가 전이 의존성으로 가져옴) 스프링이 빈으로 등록해주지 않아 `NoSuchBeanDefinitionException` 계열 오류로 컨텍스트 초기화 자체가 실패했습니다.

이 저장소의 다른 DI 대상 클래스들(`AuthController`, `CustomAuthenticationEntryPoint`, `CustomAccessDeniedHandler`)은 모두 `tools.jackson.databind.ObjectMapper`를 쓰고 있어, 이것이 이 프로젝트에서 스프링 관리 빈으로 주입받을 때의 정상 컨벤션입니다.

kordoc 기능이 머지된 시점(#403) 이후의 모든 배포가 이 문제로 계속 실패해 온 것으로 보이며, 이번 수정으로 정상화됩니다.

### 변경

- `KordocCliOcrClient`: `com.fasterxml.jackson.databind.ObjectMapper` → `tools.jackson.databind.ObjectMapper`로 교체, 그에 맞춰 `JsonProcessingException`(checked) → `tools.jackson.core.JacksonException`(unchecked)으로 예외 타입 변경
- `KordocCliOcrClientTest` 신규 추가: 실제 kordoc 출력 형태 JSON 역직렬화, 알 수 없는 필드 무시, 깨진 JSON에 대한 `ExpectedException` 처리 검증

## 관련 이슈

