### PR TITLE
[oneseo] kordoc 대신 잘못된 패키지(@clazic/kordoc)가 설치되어 OCR 실패

### DIFF
--- a/DockerfileProd
+++ b/DockerfileProd
@@ -6,7 +6,7 @@
 # 호출이 한 번 발생합니다.
 FROM node:22-slim AS ocr-tools
 
-RUN npm install -g kordoc
+RUN npm install -g kordoc@4.9.1
 
 FROM eclipse-temurin:25-jre
 

--- a/DockerfileProd
+++ b/DockerfileProd
@@ -6,7 +6,7 @@
 # 호출이 한 번 발생합니다.
 FROM node:22-slim AS ocr-tools
 
-RUN npm install -g @clazic/kordoc
+RUN npm install -g kordoc
 
 FROM eclipse-temurin:25-jre
 

--- a/DockerfileStage
+++ b/DockerfileStage
@@ -6,7 +6,7 @@
 # 호출이 한 번 발생합니다.
 FROM node:22-slim AS ocr-tools
 
-RUN npm install -g kordoc
+RUN npm install -g kordoc@4.9.1
 
 FROM eclipse-temurin:25-jre
 

--- a/DockerfileStage
+++ b/DockerfileStage
@@ -6,7 +6,7 @@
 # 호출이 한 번 발생합니다.
 FROM node:22-slim AS ocr-tools
 
-RUN npm install -g @clazic/kordoc
+RUN npm install -g kordoc
 
 FROM eclipse-temurin:25-jre
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
@@ -22,7 +22,7 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
 /**
- * kordoc(Node.js CLI, {@code @clazic/kordoc})을 subprocess로 실행합니다.
+ * kordoc(Node.js CLI, {@code kordoc})을 subprocess로 실행합니다.
  *
  * <p>
  * 별도 서비스를 두지 않고 {@link ProcessBuilder}로 직접 실행하는 방식(연동 방식 A)입니다. 트래픽이 늘어 프로세스 기동


### PR DESCRIPTION
## 배경

배포 후 스캔본 OCR 테스트 시 422(\"스캔 이미지를 인식하지 못했습니다\")가 발생했습니다. stage CloudWatch 로그(`hellogsm-stage-log`)를 확인해보니 원인은:

```
kordoc 실행 실패. exitCode=1, stderr=error: option '--ocr <mode>' argument missing
```

처음엔 `KordocCliOcrClient`가 `--ocr`을 값 없는 boolean 플래그로 호출하는 게 문제라고 판단했으나, 프론트엔드 김서연 님이 `npx @clazic/kordoc --help`로 직접 확인해 알려준 내용을 계기로 재조사한 결과 더 근본적인 원인을 확인했습니다.

## 원인

`DockerfileProd`/`DockerfileStage`가 설치하는 `@clazic/kordoc`은 이 기능을 설계할 때 리서치했던 `kordoc`(`chrisryugj/kordoc`)과 **이름만 비슷한 완전히 다른 패키지**입니다.

| | `kordoc` (의도한 패키지) | `@clazic/kordoc` (실제 설치된 패키지) |
|---|---|---|
| 저장소 | `chrisryugj/kordoc` | `clazic/kordoc` |
| 입력 | PNG/JPG/WebP 이미지 직접 지원 | HWP/HWPX/PDF/XLSX/DOCX 문서만 (이미지 미지원) |
| OCR | 내장 PP-OCRv5 Korean, `--ocr`은 값 없는 boolean 플래그 | `--ocr <mode>`로 값 필요, Gemini/Claude/Codex/Ollama 등 외부 AI API에 위임 |

npm 레지스트리(`npm view kordoc`, `npm view @clazic/kordoc`)로 두 패키지가 서로 다른 저장소임을 재확인했습니다. 즉 `KordocCliOcrClient`의 코드(`table.cells` 구조 파싱, 값 없는 `--ocr` 호출)는 원래도 올바른 `kordoc` 패키지 기준으로 맞게 작성되어 있었고, Dockerfile에서 엉뚱한 패키지를 설치한 것이 실제 원인이었습니다.

## 변경 사항

- `DockerfileProd`, `DockerfileStage`: `npm install -g @clazic/kordoc` → `npm install -g kordoc`
- `KordocCliOcrClient` 클래스 주석의 패키지명 표기(`@clazic/kordoc` → `kordoc`) 정정
- 코드 로직 변경 없음 (`--ocr` boolean 호출 방식 유지)

## 검증

- `./gradlew test --tests "*Kordoc*"`, `./gradlew spotlessApply` 통과
- 실제 kordoc 실행 환경이 이 샌드박스엔 없어 CLI 자체 재현 검증은 못했습니다. 패키지 교체 후 스캔본 OCR로 다시 E2E 테스트 부탁드립니다.