### PR TITLE
[oneseo] OCR 동시 실행 한도를 인스턴스 메모리에 맞게 낮추고 스캔 이미지 다운스케일 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
@@ -1,5 +1,8 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -7,6 +10,8 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.List;
 import java.util.Set;
+
+import javax.imageio.ImageIO;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -38,6 +43,9 @@ import team.themoment.sdk.exception.ExpectedException;
 public class ExtractOcrPageTextService {
 
     private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png");
+    // kordoc(OCR 엔진) 프로세스의 메모리 사용량은 이미지 해상도에 비례한다. 스캔 이미지는 텍스트 인식에
+    // 필요한 해상도보다 훨씬 크게 올라오는 경우가 많아, 긴 변을 이 값으로 제한해 메모리 사용량을 낮춘다.
+    private static final int MAX_DIMENSION_PX = 2000;
 
     private final KordocOcrClient kordocOcrClient;
     private final KordocAchievementTextConverter converter;
@@ -85,10 +93,49 @@ public class ExtractOcrPageTextService {
         restrictToOwner(tempFile);
         try {
             file.transferTo(tempFile);
+            downscaleIfNeeded(tempFile, extension);
             return tempFile;
         } catch (IOException e) {
             deleteQuietly(tempFile);
             throw new ExpectedException("업로드된 이미지를 처리하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /** 다운스케일은 메모리 최적화일 뿐 필수 동작이 아니므로, 실패해도 원본 해상도로 OCR을 계속 진행한다. */
+    private void downscaleIfNeeded(Path imagePath, String extension) {
+        BufferedImage original;
+        try {
+            original = ImageIO.read(imagePath.toFile());
+        } catch (IOException e) {
+            log.warn("스캔 이미지 다운스케일을 위한 읽기 실패, 원본 해상도로 진행합니다. path={}", imagePath);
+            return;
+        }
+        if (original == null) {
+            return;
+        }
+
+        int width = original.getWidth();
+        int height = original.getHeight();
+        int longestSide = Math.max(width, height);
+        if (longestSide <= MAX_DIMENSION_PX) {
+            return;
+        }
+
+        double scale = (double) MAX_DIMENSION_PX / longestSide;
+        int scaledWidth = Math.max(1, (int) Math.round(width * scale));
+        int scaledHeight = Math.max(1, (int) Math.round(height * scale));
+
+        BufferedImage scaled = new BufferedImage(scaledWidth, scaledHeight, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = scaled.createGraphics();
+        graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        graphics.drawImage(original, 0, 0, scaledWidth, scaledHeight, null);
+        graphics.dispose();
+
+        String formatName = "png".equalsIgnoreCase(extension) ? "png" : "jpg";
+        try {
+            ImageIO.write(scaled, formatName, imagePath.toFile());
+        } catch (IOException e) {
+            log.warn("스캔 이미지 다운스케일 결과 저장 실패, 원본 해상도로 진행합니다. path={}", imagePath);
         }
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextService.java
@@ -130,12 +130,16 @@ public class ExtractOcrPageTextService {
         graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         graphics.drawImage(original, 0, 0, scaledWidth, scaledHeight, null);
         graphics.dispose();
+        // 원본 해상도 래스터는 여기서부터 더 이상 필요 없으므로, GC를 기다리지 않고 즉시 반환합니다.
+        original.flush();
 
         String formatName = "png".equalsIgnoreCase(extension) ? "png" : "jpg";
         try {
             ImageIO.write(scaled, formatName, imagePath.toFile());
         } catch (IOException e) {
             log.warn("스캔 이미지 다운스케일 결과 저장 실패, 원본 해상도로 진행합니다. path={}", imagePath);
+        } finally {
+            scaled.flush();
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,8 +93,10 @@ oneseo:
     # 개인정보가 그대로 노출되므로 운영 환경에서는 반드시 false여야 합니다.
     expose-raw-text: ${EXTRACTION_EXPOSE_RAW_TEXT:false}
     ocr:
-      # kordoc subprocess 동시 실행 최대 개수. 트래픽이 늘면 조정하고, 필요하면 방식 B(별도 마이크로서비스)로 전환합니다.
-      max-concurrent-jobs: ${EXTRACTION_OCR_MAX_CONCURRENT_JOBS:2}
+      # kordoc subprocess 동시 실행 최대 개수. kordoc 프로세스 1개당 ~200-400MB를 쓰는데 스테이지
+      # 인스턴스 메모리가 1.8GB뿐이라 2로 두면 OOM이 난다(2026-08-23 스테이지 장애). 인스턴스 메모리를
+      # 늘리기 전까지는 1로 유지하고, 트래픽이 늘면 방식 B(별도 마이크로서비스)로 전환을 검토합니다.
+      max-concurrent-jobs: ${EXTRACTION_OCR_MAX_CONCURRENT_JOBS:1}
       # 동시 실행 한도가 찼을 때 자리가 날 때까지 기다리는 시간
       acquire-timeout-seconds: ${EXTRACTION_OCR_ACQUIRE_TIMEOUT_SECONDS:5}
       # kordoc 프로세스 자체의 실행 제한 시간

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ExtractOcrPageTextServiceTest.java
@@ -7,9 +7,15 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.imageio.ImageIO;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -109,6 +115,39 @@ class ExtractOcrPageTextServiceTest {
                 ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
                 verify(kordocOcrClient).recognize(pathCaptor.capture());
                 assertThat(Files.exists(pathCaptor.getValue())).isFalse();
+            }
+        }
+
+        @Nested
+        @DisplayName("긴 변이 2000px을 넘는 이미지가 주어진 경우")
+        class Context_with_oversized_image {
+
+            @Test
+            @DisplayName("kordoc에 전달하기 전 긴 변을 2000px로 축소한다")
+            void it_downscales_before_passing_to_kordoc() throws IOException {
+                byte[] oversizedJpeg = createJpeg(3000, 1500);
+                MultipartFile file = new MockMultipartFile("file", "page.jpg", "image/jpeg", oversizedJpeg);
+                KordocParseResult parseResult = new KordocParseResult(List.of());
+                AtomicInteger capturedLongestSide = new AtomicInteger();
+
+                given(kordocOcrClient.recognize(any())).willAnswer(invocation -> {
+                    Path path = invocation.getArgument(0);
+                    BufferedImage image = ImageIO.read(path.toFile());
+                    capturedLongestSide.set(Math.max(image.getWidth(), image.getHeight()));
+                    return parseResult;
+                });
+                given(converter.convert(parseResult)).willReturn(new KordocConversionResult("", List.of()));
+
+                service.execute(file);
+
+                assertThat(capturedLongestSide.get()).isEqualTo(2000);
+            }
+
+            private byte[] createJpeg(int width, int height) throws IOException {
+                BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                ImageIO.write(image, "jpg", out);
+                return out.toByteArray();
             }
         }
     }


### PR DESCRIPTION
## 배경

2026-08-23 스테이지에서 생기부 OCR 테스트 중 서버 전체가 OOM으로 다운되는 장애가 있었습니다. 원인을 추적한 결과:

- kordoc(OCR 엔진)은 요청마다 별도 `node` 프로세스를 띄우는데, 프로세스 하나당 200~400MB를 씁니다.
- 스테이지 인스턴스 메모리는 1.8GB뿐인데, 기존 `OcrConcurrencyGate`의 동시 실행 한도(`max-concurrent-jobs`)가 2로 설정되어 있었습니다.
- 실제로 OCR 테스트 요청 2건이 겹치면서 메모리를 초과, 커널 OOM killer가 Java 프로세스를 강제 종료했습니다(`dmesg`로 확인).

## 변경 사항

- `application.yml`: `oneseo.extraction.ocr.max-concurrent-jobs` 기본값 2 → 1
- `ExtractOcrPageTextService`: 업로드된 스캔 이미지의 긴 변이 2000px를 넘으면 OCR 호출 전에 미리 축소 — kordoc 프로세스당 메모리 사용량 자체도 낮춥니다.

## 검증

- 단위 테스트 추가: 3000×1500 이미지가 2000px로 축소되어 kordoc에 전달되는지 확인
- 전체 테스트 스위트 통과
- 스테이지 인스턴스에서 실제 EC2 메모리/프로세스 상태를 SSM으로 직접 확인하며 원인 규명