### PR TITLE
[oneseo] 성적표에서 교과/과목이 별도 열로 나뉜 경우 과목명 열 오인식 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverter.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverter.java
@@ -36,7 +36,9 @@ public class KordocAchievementTextConverter {
     // 블록 텍스트 전체가 학년 표시 그 자체일 때만 인정합니다. 부분 일치를 허용하면 "2024학년도 생활기록부" 같은 제목이나
     // "학년별 출결현황" 같은 캡션에도 반응해 엉뚱한 [N학년] 줄을 끼워 넣고, 문서 전체의 학년 판정을 틀어지게 합니다.
     private static final Pattern GRADE_HEADING = Pattern.compile("^\\[?\\s*([1-3])?\\s*학년\\s*]?$");
-    private static final Pattern BARE_SEMESTER = Pattern.compile("^[12]$");
+    // rowSpan으로 병합된 학기 셀을 kordoc이 펼치면서 "1"이 아니라 "111111"처럼 같은 숫자가 줄바꿈 없이 반복되는
+    // 경우가 있어, 단일 숫자뿐 아니라 같은 숫자의 반복도 학기 표시로 인정합니다.
+    private static final Pattern BARE_SEMESTER = Pattern.compile("^([12])\\1*$");
     // 원점수/과목평균 부분은 SUBJECT_ROW와 동일하게 선택 사항입니다. 예체능처럼 성취도만 있는 과목이 이 표에 섞여
     // 나올 가능성을 배제할 수 없어, 점수 없이 성취도 글자만 있는 줄도 원점수/성취도 열로 인식합니다.
     private static final Pattern SCORE_LINE = Pattern
@@ -85,12 +87,14 @@ public class KordocAchievementTextConverter {
             List<String> scoreLines = scoreCell.get().textOrEmpty().lines().map(String::strip)
                     .filter(line -> !line.isEmpty()).toList();
 
-            Optional<KordocTableCell> subjectCell = findSubjectCell(cells, scoreCell.get());
-            Optional<List<String>> subjects = subjectCell
-                    .flatMap(cell -> subjectTokenizer.tokenize(cell.textOrEmpty(), scoreLines.size()));
+            List<KordocTableCell> subjectCandidates = findSubjectCandidates(cells, scoreCell.get());
+            Optional<List<String>> subjects = subjectCandidates.stream()
+                    .map(cell -> subjectTokenizer.tokenize(cell.textOrEmpty(), scoreLines.size()))
+                    .filter(Optional::isPresent).map(Optional::get).findFirst();
 
             if (subjects.isEmpty()) {
-                subjectCell.ifPresent(cell -> unrecognizedSubjectBlobs.add(cell.textOrEmpty()));
+                mostLikelySubjectCell(subjectCandidates)
+                        .ifPresent(cell -> unrecognizedSubjectBlobs.add(cell.textOrEmpty()));
                 continue;
             }
 
@@ -109,17 +113,26 @@ public class KordocAchievementTextConverter {
         }).findFirst();
     }
 
-    /** 과목명 열: 원점수 셀도, 학기 숫자 하나짜리 셀도 아니면서 한글이 가장 많이 포함된 셀입니다. */
-    private Optional<KordocTableCell> findSubjectCell(List<KordocTableCell> cells, KordocTableCell scoreCell) {
+    /**
+     * 과목명 열 후보: 원점수 셀도, 학기 숫자 셀도 아니면서 한글을 포함한 셀들입니다. "교과"(대분류)와 "과목"(실제 과목명)이 별도 열로
+     * 나뉜 표에서는 두 열 모두 한글을 포함하므로, 어느 쪽이 진짜 과목명 열인지는 여기서 미리 정하지 않고 호출자가 각 후보에 실제로 토큰화를
+     * 시도해 성공하는 셀을 채택합니다. 대분류 열은 "(역사포함)" 같은 부가 설명이 섞여 있어 표준 과목 사전만으로는 절대 빈틈없이 분해되지
+     * 않으므로, 이렇게 하면 자연히 걸러집니다.
+     */
+    private List<KordocTableCell> findSubjectCandidates(List<KordocTableCell> cells, KordocTableCell scoreCell) {
         return cells.stream().filter(cell -> cell != scoreCell)
                 .filter(cell -> !BARE_SEMESTER.matcher(cell.textOrEmpty().strip()).matches())
-                .max(Comparator.comparingInt(cell -> countHangul(cell.textOrEmpty())))
-                .filter(cell -> countHangul(cell.textOrEmpty()) > 0);
+                .filter(cell -> countHangul(cell.textOrEmpty()) > 0).toList();
+    }
+
+    /** 후보 중 어느 것도 토큰화에 성공하지 못했을 때, 검수 대상으로 보여줄 셀 — 한글이 가장 많은 셀을 그대로 돌려줍니다. */
+    private Optional<KordocTableCell> mostLikelySubjectCell(List<KordocTableCell> candidates) {
+        return candidates.stream().max(Comparator.comparingInt(cell -> countHangul(cell.textOrEmpty())));
     }
 
     private Optional<String> findSemesterDigit(List<KordocTableCell> cells) {
-        return cells.stream().map(cell -> cell.textOrEmpty().strip())
-                .filter(text -> BARE_SEMESTER.matcher(text).matches()).findFirst();
+        return cells.stream().map(cell -> cell.textOrEmpty().strip()).map(BARE_SEMESTER::matcher)
+                .filter(Matcher::matches).map(matcher -> matcher.group(1)).findFirst();
     }
 
     private int countHangul(String text) {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverterTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocAchievementTextConverterTest.java
@@ -96,6 +96,32 @@ class KordocAchievementTextConverterTest {
         }
 
         @Nested
+        @DisplayName("교과(대분류)와 과목(실제 과목명)이 별도 열로 나뉜 표가 주어진 경우")
+        class Context_with_separate_category_and_subject_columns {
+
+            @Test
+            @DisplayName("한글이 더 많은 대분류 열이 아니라 실제로 토큰화에 성공하는 과목 열을 사용한다")
+            void it_picks_the_column_that_actually_tokenizes() {
+                // 실제 kordoc 출력에서 확인된 형태: rowSpan 병합 셀이 줄바꿈 없이 반복되어 "1"이 "111111"로,
+                // "교과" 열은 "(역사포함)" 같은 부가 설명과 "/" 구분자가 섞인 채로 재구성됩니다.
+                KordocTableCell semesterCell = new KordocTableCell("111111", 1, 1);
+                KordocTableCell categoryCell = new KordocTableCell(String
+                        .join("\n", "사회(역사포함)/도덕", "사회(역사포함)/도덕수학", "과학/기술·가정/정보", "과학/기술·가정/정보영어"), 1, 1);
+                KordocTableCell subjectCell = new KordocTableCell(String.join("\n", "사회도덕수학과학", "기술·가정영어"), 1, 1);
+                KordocTableCell scoreCell = new KordocTableCell(String.join("\n", "P", "P", "P", "P", "P", "P"), 1, 1);
+                KordocTable table = new KordocTable(
+                        List.of(List.of(semesterCell, categoryCell, subjectCell, scoreCell)));
+                KordocBlock tableBlock = new KordocBlock("table", null, table, 1);
+
+                KordocConversionResult conversion = converter.convert(new KordocParseResult(List.of(tableBlock)));
+
+                assertThat(conversion.unrecognizedSubjectBlobs()).isEmpty();
+                assertThat(conversion.rawText().lines())
+                        .contains("1", "사회 P", "도덕 P", "수학 P", "과학 P", "기술가정 P", "영어 P");
+            }
+        }
+
+        @Nested
         @DisplayName("원점수/성취도 열을 찾을 수 없는 행(출결 등으로 추정)이 주어진 경우")
         class Context_with_non_achievement_row {
 


### PR DESCRIPTION
## 배경

kordoc이 정상 동작하는지 검증하기 위해 실제 정부24 발급 생기부 PDF로 전체 파이프라인(kordoc → JSON → `KordocAchievementTextConverter`)을 테스트했습니다. kordoc 자체는 표를 정확히 인식했지만, 우리 쪽 변환 로직에서 해당 페이지의 과목 12개가 전부 `unrecognizedSubjectBlobs`로 빠지는 것을 확인했습니다.

## 원인

`findSubjectCell`은 "한글 글자 수가 가장 많은 셀"을 과목명 열로 추측합니다. 그런데 이 표는 **"교과"(대분류)와 "과목"(실제 과목명)이 별도 열로 나뉜 형태**였습니다:

```
교과 셀: "사회(역사포함)/도덕\n사회(역사포함)/도덕수학\n과학/기술·가정/정보\n과학/기술·가정/정보영어"  (한글 多)
과목 셀: "사회도덕수학과학\n기술·가정영어"                                                      (한글 少, 실제 필요한 값)
```

"교과" 열은 부가 설명((역사포함))과 구분자(/)가 섞여 있어 한글 글자 수는 항상 더 많지만, 표준 과목 사전만으로는 절대 분해되지 않습니다. 그 결과 매번 잘못된 열이 선택되어 토큰화가 실패했습니다.

부가로, rowSpan 병합된 학기 셀이 `"1"`이 아니라 `"111111"`처럼 같은 숫자가 반복되어 나오는 경우 학기 판정 정규식도 놓치는 문제가 있어 함께 수정했습니다.

## 변경 사항

- `findSubjectCell` → `findSubjectCandidates`: 한글 개수로 미리 정답을 추측하지 않고, 후보 셀들에 실제로 `KordocSubjectTokenizer`를 돌려봐서 **성공하는 셀**을 채택하도록 변경. 실패 시에는 기존처럼 한글이 가장 많은 셀을 검수용 `unrecognizedSubjectBlobs`로 보고합니다.
- `BARE_SEMESTER` 패턴을 단일 숫자뿐 아니라 같은 숫자의 반복(`"111111"`)도 인정하도록 완화

## 검증

- 실제 kordoc 출력 구조를 반영한 테스트 케이스 추가 (`Context_with_separate_category_and_subject_columns`)
- 기존 테스트 4건 모두 통과 (회귀 없음)
- 실제 생기부 페이지 데이터로 직접 재현 → 수정 후 12개 과목 전부 정상 변환 확인 (개인정보 포함 테스트 파일은 검증 후 즉시 삭제)
- 전체 테스트 스위트 통과