### PR TITLE
[oneseo] kordoc 타임아웃 시 자손 프로세스까지 강제 종료

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/ocr/KordocCliOcrClient.java
@@ -29,8 +29,8 @@ import tools.jackson.databind.ObjectMapper;
  * 오버헤드가 문제가 되면 별도 Node 마이크로서비스(방식 B)로 전환을 검토합니다.
  *
  * <p>
- * <b>검증 한계:</b> 실행 환경에 kordoc이 설치되어 있지 않아 이 클래스는 실제 kordoc 실행으로 검증하지 못했습니다. 배포
- * 전 실제 Node 환경에서 한 번 실행해 CLI 인자 · 종료 코드 · JSON 출력 형태를 확인해야 합니다.
+ * 2026-08-24 스테이지 환경에서 실제 kordoc 실행(CLI 인자 · 종료 코드 · JSON 출력 형태 · 타임아웃 동작)으로
+ * 검증했습니다.
  */
 @Slf4j
 @Component
@@ -65,7 +65,7 @@ public class KordocCliOcrClient implements KordocOcrClient {
 
             boolean finished = process.waitFor(processTimeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
-                process.destroyForcibly();
+                destroyProcessTree(process);
                 throw new ExpectedException("OCR 처리 시간이 너무 오래 걸려 중단했습니다. 다시 시도해주세요.", HttpStatus.GATEWAY_TIMEOUT);
             }
             if (process.exitValue() != 0) {
@@ -84,6 +84,16 @@ public class KordocCliOcrClient implements KordocOcrClient {
             deleteQuietly(stdoutFile);
             deleteQuietly(stderrFile);
         }
+    }
+
+    /**
+     * npx는 실제 OCR 작업을 자식(node) 프로세스에 위임하므로, npx 프로세스만 죽이면 그 자식은 고아 프로세스로 남아 CPU를 계속
+     * 점유한다. 2026-08-24 스테이지에서 이 때문에 30초 타임아웃 처리가 실제 응답까지는 242초나 걸린 사례가 있었다. 자손
+     * 프로세스까지 전부 강제 종료한다.
+     */
+    private void destroyProcessTree(Process process) {
+        process.descendants().forEach(ProcessHandle::destroyForcibly);
+        process.destroyForcibly();
     }
 
     KordocParseResult parseJson(String json) {


### PR DESCRIPTION
## 배경

이전 PR(#408, #409)이 머지된 뒤 프론트에서 실제 정부24 발급 생기부 페이지 이미지로 OCR을 테스트하다가 500(정확히는 504)을 겪었습니다. 스테이지 CloudWatch 로그로 원인을 추적했습니다.

## 타임라인

1. `16:43:59` — 프론트에서 `/oneseo/v3/extraction/middle-school-achievement/ocr-page`로 실제 성적표 이미지 업로드
2. 코드상 `processTimeoutSeconds`(기본 30초) 뒤에는 Java가 타임아웃으로 판단하고 `504`를 던지도록 되어 있음
3. 하지만 실제 응답이 로그에 찍힌 건 `16:48:01` — **Response Time: 242406ms (약 242초)**
4. 그 시점 EC2의 `load average`가 `1분: 0.45 / 5분: 13.24 / 15분: 11.15`로, 최근 몇 분간 CPU가 심하게 몰렸다가 막 가라앉은 상태였고 zombie 프로세스도 1개 남아 있었음

## 원인

`KordocCliOcrClient.recognize()`가 `npx kordoc ...`을 서브프로세스로 띄우는데, `npx`는 실제 OCR 작업을 **자식(node) 프로세스에 위임**합니다. 타임아웃 시 호출하던 `process.destroyForcibly()`는 `npx` 프로세스 자체만 죽이고, 그 자식(실제 OCR 엔진)은 고아 프로세스로 남아 CPU를 계속 점유합니다.

그 결과 Java 쪽은 30초 만에 이미 504를 던지기로 결정했지만, 고아 프로세스가 CPU를 붙잡고 있어 그 응답을 실제로 클라이언트에 내보내기까지(HTTP 응답 직렬화, 로깅 등) 추가로 몇 분이 더 걸린 것으로 보입니다. 사용자 입장에서는 그냥 오래 걸리다 실패한 것처럼 보였을 것입니다.

## 변경 사항

- `Process#descendants()`로 자손 프로세스까지 전부 순회하며 `destroyForcibly()` 호출 (`destroyProcessTree` 메서드 추가)
- 클래스 Javadoc의 오래된 "검증 안 됨" 주석을 실제 검증 이력으로 갱신

## 검증

- 컴파일 및 기존 단위 테스트(`KordocCliOcrClientTest`) 통과
- OS 프로세스 트리 종료라는 특성상 결정적인 단위 테스트로 재현하기 어려워, 별도 테스트는 추가하지 않았습니다. 머지 후 스테이지에 배포되면 동일한 이미지로 재현 테스트를 진행할 예정입니다.