### PR TITLE
[global] docker가 있는 인스턴스 실행 시 기존 컨테이너 삭제 방지

### DIFF
--- a/scripts/stage-deploy.sh
+++ b/scripts/stage-deploy.sh
@@ -18,4 +18,4 @@ docker build -t $IMAGE_NAME -f $DOCKERFILE_NAME .
 
 docker run -d --name $CONTAINER_NAME -p 8080:8080 $IMAGE_NAME
 
-docker system prune -a --volumes -f
+docker system prune -a -f


### PR DESCRIPTION
## 개요

## 개요

AWS의 EC2를 주기적으로 재부팅함에 따라 `docker system prune -a --volumes -f` 명령어로 인해 mysql, redis 컨테이너가 어떤 이유로든 꺼져있다면 그 볼륨이 미사용으로 판단되어 데이터베이스 데이터가 통째로 날라갑니다.

그래서 볼륨을 건드리지 않도록 `docker system prune -a -f`로 수정하였습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
