### PR TITLE
[oneseo] 프론트 OCR 실행 전 인증 API 추가 (세션 검증 + rate limit)

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoExtractionController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoExtractionController.java
@@ -13,8 +13,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ExtractMiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ExtractedAchievementResDto;
+import team.themoment.hellogsmv3.domain.oneseo.service.AuthorizeOcrService;
 import team.themoment.hellogsmv3.domain.oneseo.service.ExtractMiddleSchoolAchievementService;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
+import team.themoment.sdk.response.CommonApiResponse;
 
 @Tag(name = "Oneseo Extraction API", description = "생활기록부 성적 추출 관련 API입니다.")
 @RestController
@@ -23,6 +25,7 @@ import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
 public class OneseoExtractionController {
 
     private final ExtractMiddleSchoolAchievementService extractMiddleSchoolAchievementService;
+    private final AuthorizeOcrService authorizeOcrService;
 
     @Operation(summary = "생활기록부 성적 추출", description = "클라이언트가 생활기록부에서 뽑아 보낸 텍스트를 중학교 성적으로 구조화합니다. 원본 파일은 서버로 전송되지 않으며, 원서 데이터를 수정하지 않습니다. 추출 결과는 사용자가 검토한 뒤 원서 등록 API로 제출해야 합니다.")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "추출 성공"),
@@ -32,5 +35,14 @@ public class OneseoExtractionController {
             @RequestBody @Valid ExtractMiddleSchoolAchievementReqDto reqDto,
             @AuthRequest Long memberId) {
         return extractMiddleSchoolAchievementService.execute(reqDto, memberId);
+    }
+
+    @Operation(summary = "생활기록부 스캔 페이지 OCR 실행 인증", description = "프론트가 kordoc OCR을 실행하기 직전에 호출합니다. 로그인 여부는 인증 필터에서 걸러지고, 이 API는 회원별 OCR 요청 횟수 제한을 확인합니다. 통과해야만 프론트가 OCR을 실행합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "인증 통과"),
+            @ApiResponse(responseCode = "429", description = "최근 OCR 요청이 너무 많은 경우")})
+    @PostMapping("/middle-school-achievement/ocr-authorize")
+    public CommonApiResponse authorizeOcr(@AuthRequest Long memberId) {
+        authorizeOcrService.execute(memberId);
+        return CommonApiResponse.success("인증되었습니다.");
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrService.java
@@ -1,0 +1,48 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+
+/**
+ * 프론트(Next.js API Route)가 kordoc OCR을 실행하기 직전에 호출합니다. 로그인 여부는 이 엔드포인트 자체가 이미
+ * {@code APPLICANT_OR_ROOT} 권한을 요구하므로 Spring Security가 먼저 걸러주고, 여기서는 회원별 OCR 요청
+ * 횟수만 확인합니다.
+ *
+ * <p>
+ * OCR 실행 자체는 프론트(Vercel)에서 이루어지므로, 여기서 막는 것은 "OCR을 실행해도 되는지"에 대한 허가일 뿐 실제 처리량을
+ * 제어하지는 않습니다 — 프론트가 이 허가를 받은 뒤에만 OCR을 실행하는 것을 전제로 합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthorizeOcrService {
+
+    private static final String REDIS_KEY_PREFIX = "ocr-rate-limit:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${oneseo.extraction.ocr-rate-limit.max-requests:30}")
+    private int maxRequests;
+
+    @Value("${oneseo.extraction.ocr-rate-limit.window-minutes:10}")
+    private long windowMinutes;
+
+    public void execute(Long memberId) {
+        String key = REDIS_KEY_PREFIX + memberId;
+
+        Long count = redisTemplate.opsForValue().increment(key);
+        if (count != null && count == 1L) {
+            redisTemplate.expire(key, Duration.ofMinutes(windowMinutes));
+        }
+
+        if (count != null && count > maxRequests) {
+            throw new ExpectedException("OCR 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS);
+        }
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrService.java
@@ -10,15 +10,6 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import team.themoment.sdk.exception.ExpectedException;
 
-/**
- * 프론트(Next.js API Route)가 kordoc OCR을 실행하기 직전에 호출합니다. 로그인 여부는 이 엔드포인트 자체가 이미
- * {@code APPLICANT_OR_ROOT} 권한을 요구하므로 Spring Security가 먼저 걸러주고, 여기서는 회원별 OCR 요청
- * 횟수만 확인합니다.
- *
- * <p>
- * OCR 실행 자체는 프론트(Vercel)에서 이루어지므로, 여기서 막는 것은 "OCR을 실행해도 되는지"에 대한 허가일 뿐 실제 처리량을
- * 제어하지는 않습니다 — 프론트가 이 허가를 받은 뒤에만 OCR을 실행하는 것을 전제로 합니다.
- */
 @Service
 @RequiredArgsConstructor
 public class AuthorizeOcrService {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrService.java
@@ -28,7 +28,8 @@ public class AuthorizeOcrService {
         String key = REDIS_KEY_PREFIX + memberId;
 
         Long count = redisTemplate.opsForValue().increment(key);
-        if (count != null && count == 1L) {
+        Long ttl = redisTemplate.getExpire(key);
+        if (ttl != null && ttl < 0) {
             redisTemplate.expire(key, Duration.ofMinutes(windowMinutes));
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,7 +92,6 @@ oneseo:
     # 개인정보가 그대로 노출되므로 운영 환경에서는 반드시 false여야 합니다.
     expose-raw-text: ${EXTRACTION_EXPOSE_RAW_TEXT:false}
     ocr-rate-limit:
-      # 프론트에서 OCR을 실행하기 전 인증 API를 호출할 때, 회원 1명이 이 시간(분) 안에 호출할 수 있는 최대 횟수
       max-requests: ${EXTRACTION_OCR_RATE_LIMIT_MAX:30}
       window-minutes: ${EXTRACTION_OCR_RATE_LIMIT_WINDOW_MINUTES:10}
 schedule:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,10 @@ oneseo:
     # 데모 진단용. 전달받은 생활기록부 원문을 응답에 되돌려줍니다.
     # 개인정보가 그대로 노출되므로 운영 환경에서는 반드시 false여야 합니다.
     expose-raw-text: ${EXTRACTION_EXPOSE_RAW_TEXT:false}
+    ocr-rate-limit:
+      # 프론트에서 OCR을 실행하기 전 인증 API를 호출할 때, 회원 1명이 이 시간(분) 안에 호출할 수 있는 최대 횟수
+      max-requests: ${EXTRACTION_OCR_RATE_LIMIT_MAX:30}
+      window-minutes: ${EXTRACTION_OCR_RATE_LIMIT_WINDOW_MINUTES:10}
 schedule:
   oneseoSubmissionStart: ${ONESEO_SUBMISSION_START}
   oneseoSubmissionEnd: ${ONESEO_SUBMISSION_END}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrServiceTest.java
@@ -1,0 +1,95 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import team.themoment.sdk.exception.ExpectedException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OCR 실행 인증 서비스 테스트")
+class AuthorizeOcrServiceTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private AuthorizeOcrService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AuthorizeOcrService(redisTemplate);
+        ReflectionTestUtils.setField(service, "maxRequests", 3);
+        ReflectionTestUtils.setField(service, "windowMinutes", 10L);
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("회원의 최근 요청 횟수가 한도 이내인 경우")
+        class Context_within_limit {
+
+            @Test
+            @DisplayName("예외를 던지지 않는다")
+            void it_does_not_throw() {
+                given(redisTemplate.opsForValue()).willReturn(valueOperations);
+                given(valueOperations.increment("ocr-rate-limit:1")).willReturn(2L);
+
+                service.execute(1L);
+
+                verify(redisTemplate, never()).expire("ocr-rate-limit:1", Duration.ofMinutes(10));
+            }
+        }
+
+        @Nested
+        @DisplayName("이번 요청이 해당 회원의 첫 요청인 경우")
+        class Context_first_request {
+
+            @Test
+            @DisplayName("만료 시간을 설정한다")
+            void it_sets_expiration() {
+                given(redisTemplate.opsForValue()).willReturn(valueOperations);
+                given(valueOperations.increment("ocr-rate-limit:1")).willReturn(1L);
+
+                service.execute(1L);
+
+                verify(redisTemplate).expire("ocr-rate-limit:1", Duration.ofMinutes(10));
+            }
+        }
+
+        @Nested
+        @DisplayName("회원의 최근 요청 횟수가 한도를 초과한 경우")
+        class Context_over_limit {
+
+            @Test
+            @DisplayName("ExpectedException(429)을 던진다")
+            void it_throws_too_many_requests() {
+                given(redisTemplate.opsForValue()).willReturn(valueOperations);
+                given(valueOperations.increment("ocr-rate-limit:1")).willReturn(4L);
+
+                assertThatThrownBy(() -> service.execute(1L)).isInstanceOf(ExpectedException.class)
+                        .extracting(e -> ((ExpectedException) e).getStatusCode())
+                        .isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/AuthorizeOcrServiceTest.java
@@ -38,6 +38,7 @@ class AuthorizeOcrServiceTest {
         service = new AuthorizeOcrService(redisTemplate);
         ReflectionTestUtils.setField(service, "maxRequests", 3);
         ReflectionTestUtils.setField(service, "windowMinutes", 10L);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
     }
 
     @Nested
@@ -45,34 +46,34 @@ class AuthorizeOcrServiceTest {
     class Describe_execute {
 
         @Nested
-        @DisplayName("회원의 최근 요청 횟수가 한도 이내인 경우")
-        class Context_within_limit {
-
-            @Test
-            @DisplayName("예외를 던지지 않는다")
-            void it_does_not_throw() {
-                given(redisTemplate.opsForValue()).willReturn(valueOperations);
-                given(valueOperations.increment("ocr-rate-limit:1")).willReturn(2L);
-
-                service.execute(1L);
-
-                verify(redisTemplate, never()).expire("ocr-rate-limit:1", Duration.ofMinutes(10));
-            }
-        }
-
-        @Nested
-        @DisplayName("이번 요청이 해당 회원의 첫 요청인 경우")
-        class Context_first_request {
+        @DisplayName("키에 만료 시간이 설정되어 있지 않은 경우 (첫 요청이거나, 이전 요청이 만료 설정 전에 중단된 경우)")
+        class Context_without_ttl {
 
             @Test
             @DisplayName("만료 시간을 설정한다")
             void it_sets_expiration() {
-                given(redisTemplate.opsForValue()).willReturn(valueOperations);
-                given(valueOperations.increment("ocr-rate-limit:1")).willReturn(1L);
+                given(valueOperations.increment("ocr-rate-limit:1")).willReturn(2L);
+                given(redisTemplate.getExpire("ocr-rate-limit:1")).willReturn(-1L);
 
                 service.execute(1L);
 
                 verify(redisTemplate).expire("ocr-rate-limit:1", Duration.ofMinutes(10));
+            }
+        }
+
+        @Nested
+        @DisplayName("키에 만료 시간이 이미 설정되어 있는 경우")
+        class Context_with_ttl {
+
+            @Test
+            @DisplayName("만료 시간을 다시 설정하지 않는다")
+            void it_does_not_reset_expiration() {
+                given(valueOperations.increment("ocr-rate-limit:1")).willReturn(2L);
+                given(redisTemplate.getExpire("ocr-rate-limit:1")).willReturn(300L);
+
+                service.execute(1L);
+
+                verify(redisTemplate, never()).expire("ocr-rate-limit:1", Duration.ofMinutes(10));
             }
         }
 
@@ -83,8 +84,8 @@ class AuthorizeOcrServiceTest {
             @Test
             @DisplayName("ExpectedException(429)을 던진다")
             void it_throws_too_many_requests() {
-                given(redisTemplate.opsForValue()).willReturn(valueOperations);
                 given(valueOperations.increment("ocr-rate-limit:1")).willReturn(4L);
+                given(redisTemplate.getExpire("ocr-rate-limit:1")).willReturn(300L);
 
                 assertThatThrownBy(() -> service.execute(1L)).isInstanceOf(ExpectedException.class)
                         .extracting(e -> ((ExpectedException) e).getStatusCode())


### PR DESCRIPTION
## 배경

프론트 OCR 라우트(`apps/client/src/app/api/school-record-ocr/route.ts`) 코드 리뷰에서, 로그인 여부·요청 횟수 제한 없이 누구나 무거운 kordoc OCR을 실행할 수 있다는 지적이 있었습니다. 논의 결과:

- **세션 검증**: 프론트 Route가 OCR 실행 전 백엔드에 물어봐서 판단 (백엔드가 세션의 유효성을 아는 유일한 주체)
- **Rate limit**: 백엔드에서 로그인 회원(`memberId`) 기준으로 적용 — GSM 지원자들은 같은 학교 네트워크(NAT)를 공유하는 경우가 많아, Vercel Edge의 IP 기반 제한은 같은 학교 학생들끼리 서로 오탐이 날 수 있음. 이미 세션용 Redis가 있어 추가 인프라도 불필요.
- 두 가지를 하나의 엔드포인트로 묶어서, 프론트가 OCR 실행 직전에 한 번만 호출하면 되도록 함 (왕복 추가 없음)

## 변경 사항

- `POST /oneseo/v3/extraction/middle-school-achievement/ocr-authorize` 추가
  - 로그인 여부: 기존 `SecurityConfig`의 `POST /oneseo/v3/extraction/**` → `APPLICANT_OR_ROOT` 규칙이 그대로 적용되어 별도 코드 없이 처리됨
  - 회원별 OCR 요청 횟수: Redis(`INCR` + `EXPIRE` 고정 윈도)로 제한, 초과 시 `429 TOO_MANY_REQUESTS`
- `application.yml`: `oneseo.extraction.ocr-rate-limit.max-requests`(기본 30) / `window-minutes`(기본 10) 설정 추가

## 검증

- 단위 테스트 3건 (첫 요청 시 만료시간 설정 / 한도 이내 통과 / 한도 초과 시 429) 통과
- 전체 테스트 스위트 통과
