### PR TITLE
[global] 스테이지 배포 docker compose 전환

### DIFF
--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -1,0 +1,71 @@
+services:
+  hellogsm-mysql:
+    image: mysql:8.0
+    container_name: hellogsm-mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-unused-existing-volume-ignores-this}
+      MYSQL_DATABASE: hellogsm
+      MYSQL_CHARACTER_SET_SERVER: utf8mb4
+      MYSQL_COLLATION_SERVER: utf8mb4_unicode_ci
+    ports:
+      - "3306:3306"
+    volumes:
+      - hellogsm-mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  hellogsm-redis:
+    image: redis:7-alpine
+    container_name: hellogsm-redis
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - hellogsm-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  hellogsm-stage-server:
+    image: hellogsm-stage-server-img
+    container_name: hellogsm-stage-server
+    restart: always
+    build:
+      context: .
+      dockerfile: DockerfileStage
+    ports:
+      - "8080:8080"
+    depends_on:
+      hellogsm-mysql:
+        condition: service_healthy
+      hellogsm-redis:
+        condition: service_healthy
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  hellogsm-mysql-data:
+    external: true
+  hellogsm-redis-data:
+    external: true

--- a/scripts/stage-deploy.sh
+++ b/scripts/stage-deploy.sh
@@ -1,21 +1,8 @@
 #!/bin/bash
 
-IMAGE_NAME=hellogsm-stage-server-img
-CONTAINER_NAME=hellogsm-stage-server
-DOCKERFILE_NAME=DockerfileStage
-
-EXISTING_CONTAINER_ID=$(docker ps -a -q -f name=$CONTAINER_NAME)
-
-if [ ! -z "$EXISTING_CONTAINER_ID" ]
-then
-  echo "현재 이전버전의 컨테이너가 있습니다. 중지하고 삭제합니다."
-  docker stop $CONTAINER_NAME || true
-  docker rm $CONTAINER_NAME
-fi
-
 cd /home/ec2-user/builds/
-docker build -t $IMAGE_NAME -f $DOCKERFILE_NAME .
 
-docker run -d --name $CONTAINER_NAME -p 8080:8080 $IMAGE_NAME
+docker compose -f docker-compose.stage.yml up -d --build hellogsm-stage-server
 
-docker system prune -a --volumes -f
+docker system prune -a -f
+docker builder prune -a -f


### PR DESCRIPTION
## 개요

스테이지 EC2 재부팅 시 `hellogsm-stage-server`가 `hellogsm-mysql`보다 먼저 기동되어 `Connection refused`로 애플리케이션 부팅이 실패하는 경쟁 상태(race condition)를 해결하였습니다. 배포 방식을 개별 `docker run`에서 `docker compose`의 `depends_on` + `condition: service_healthy`로 전환하였습니다.

## 본문

기존에는 `hellogsm-mysql`, `hellogsm-redis`, `hellogsm-stage-server` 세 컨테이너 모두 `restart: always`로 설정되어 있어, EC2가 재부팅되면 Docker 데몬이 세 컨테이너를 동시에 재기동하였습니다. `hellogsm-stage-server`가 `hellogsm-mysql`의 초기화가 끝나기 전에 `EntityManagerFactory`를 생성하려 시도하면서 `JDBCConnectionException: Connection refused`로 부팅에 실패하는 사례가 발생하였습니다.

이를 해결하기 위해 `docker-compose.stage.yml`을 새로 작성하여 `hellogsm-mysql`, `hellogsm-redis`에 `healthcheck`를 추가하고, `hellogsm-stage-server`가 두 서비스 모두 `service_healthy` 상태가 될 때까지 대기하도록 `depends_on` 조건을 구성하였습니다. 기존 데이터 볼륨(`hellogsm-mysql-data`, `hellogsm-redis-data`)은 `external: true`로 재사용하여 데이터 유실 위험 없이 전환하였습니다.

`docker-compose.stage.yml`의 `DB_URL`, `REDIS_HOST`는 각각 `hellogsm-mysql`, `hellogsm-redis` 서비스명으로 접근하며, 이에 맞춰 GitHub Secret `STAGE_WEB_YML`도 기존 컨테이너 고정 IP(`172.17.0.2`, `172.17.0.3`) 대신 서비스명을 사용하도록 별도로 갱신하였습니다.

### 변경

- `scripts/stage-deploy.sh`: 개별 `docker run` 방식에서 `docker compose -f docker-compose.stage.yml up -d --build hellogsm-stage-server`로 전환하여 `hellogsm-stage-server`만 재빌드/재기동하도록 수정하였습니다.
- 기존 `docker system prune -a --volumes -f`에서 `--volumes` 옵션을 제거하였습니다. 배포 스크립트 실행 시점에 `hellogsm-mysql`, `hellogsm-redis` 컨테이너가 일시적으로 내려가 있으면 해당 볼륨이 미사용으로 판단되어 삭제될 위험이 있었습니다.
- `docker builder prune -a -f`를 추가하여 빌드 캐시 누적을 방지하였습니다.

### 추가

- `docker-compose.stage.yml`: `hellogsm-mysql`, `hellogsm-redis`, `hellogsm-stage-server` 세 서비스를 정의하고, 각 서비스에 `logging` 드라이버 옵션(`max-size: 10m`, `max-file: 3`)을 추가하여 컨테이너 로그가 무제한으로 누적되는 문제를 방지하였습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
c: 웬만하면 반영해 주세요. (Comment)
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
