### PR TITLE
[global] 스테이지 CD docker-compose 배포 실패 수정

### DIFF
--- a/.github/workflows/hellogsm-stage-cd.yml
+++ b/.github/workflows/hellogsm-stage-cd.yml
@@ -49,6 +49,7 @@ jobs:
           cp build/libs/*.jar deploy/build/libs/
           cp appspec.yml deploy/
           cp DockerfileStage deploy/
+          cp docker-compose.stage.yml deploy/
           cp -r scripts deploy/
           cd deploy && zip -r ../$GITHUB_SHA.zip .
         shell: bash

--- a/scripts/stage-deploy.sh
+++ b/scripts/stage-deploy.sh
@@ -2,7 +2,7 @@
 
 cd /home/ec2-user/builds/
 
-docker compose -f docker-compose.stage.yml up -d --build hellogsm-stage-server
+docker-compose -f docker-compose.stage.yml up -d --build hellogsm-stage-server
 
 docker system prune -a -f
 docker builder prune -a -f


### PR DESCRIPTION
## 개요

`docker-compose.stage.yml`을 도입한 직전 PR(#414) 머지 후 스테이지 CD가 실패한 두 가지 원인을 수정하였습니다.

## 본문

PR #414 머지 후 CD가 실행되었으나 다음 두 가지 문제로 배포에 실패하였습니다.

첫째, `hellogsm-stage-cd.yml`의 `Make ZIP File` 단계가 `docker-compose.stage.yml`을 배포 ZIP에 포함하지 않아, EC2에서 `stage-deploy.sh` 실행 시 `open /home/ec2-user/builds/docker-compose.stage.yml: no such file or directory` 에러가 발생하였습니다.

둘째, 스테이지 EC2에는 `docker compose`(V2 CLI 플러그인)가 아닌 `docker-compose`(V2.39.4, 독립 실행 바이너리)만 설치되어 있어, `stage-deploy.sh`의 `docker compose -f ...` 명령이 `unknown shorthand flag: 'f'` 에러로 실패하였습니다.

두 문제 모두 배포 스크립트 실행 자체가 실패한 것이며, 기존에 떠 있던 `hellogsm-stage-server` 컨테이너는 그대로 유지되어 서비스 중단이나 데이터 유실은 발생하지 않았습니다.

### 변경

- `hellogsm-stage-cd.yml`: `Make ZIP File` 단계에 `cp docker-compose.stage.yml deploy/`를 추가하여 배포 산출물에 compose 파일이 포함되도록 수정하였습니다.
- `stage-deploy.sh`: `docker compose`를 EC2에 실제 설치된 `docker-compose`로 수정하였습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
c: 웬만하면 반영해 주세요. (Comment)
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
