### PR TITLE
[oneseo] GET /oneseo/me에 ADMIN 권한 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -42,6 +42,8 @@ public class SecurityConfig {
     private static final String[] ADMIN_ONLY = {Role.ADMIN.name(), Role.ROOT.name()};
     private static final String[] APPLICANT_OR_ROOT = {Role.APPLICANT.name(), Role.ROOT.name()};
     private static final String[] UNAUTHENTICATED_OR_APPLICANT = {Role.UNAUTHENTICATED.name(), Role.APPLICANT.name()};
+    private static final String[] APPLICANT_OR_ADMIN_OR_ROOT = {Role.APPLICANT.name(), Role.ADMIN.name(),
+            Role.ROOT.name()};
 
     @Bean
     public Filter timeBasedFilter() {
@@ -149,7 +151,9 @@ public class SecurityConfig {
 
     private void oneseoRequests(
             AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry req) {
-        req.requestMatchers("/oneseo/v3/oneseo/me").hasAnyAuthority(APPLICANT_OR_ROOT)
+        req.requestMatchers(HttpMethod.GET, "/oneseo/v3/oneseo/me").hasAnyAuthority(APPLICANT_OR_ADMIN_OR_ROOT)
+                .requestMatchers(HttpMethod.POST, "/oneseo/v3/oneseo/me").hasAnyAuthority(APPLICANT_OR_ROOT)
+                .requestMatchers(HttpMethod.PUT, "/oneseo/v3/oneseo/me").hasAnyAuthority(APPLICANT_OR_ROOT)
                 .requestMatchers("/oneseo/v3/oneseo/{memberId}").hasAnyAuthority(ADMIN_ONLY)
                 .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/arrived-status/{memberId}").hasAnyAuthority(ADMIN_ONLY)
                 .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/competency-score/{memberId}").hasAnyAuthority(ADMIN_ONLY)


### PR DESCRIPTION
## 개요

`ADMIN` 계정으로 `GET /oneseo/v3/oneseo/me` 호출 시 403이 발생하는 문제를 수정하였습니다.

## 본문

`SecurityConfig`의 `oneseoRequests()`에서 `/oneseo/v3/oneseo/me` 경로가 HTTP 메서드 구분 없이 하나의 `requestMatchers`로 묶여 `APPLICANT_OR_ROOT` 권한만 허용하고 있었습니다. 이로 인해 `ADMIN` 계정이 원서 임시저장 여부를 확인하기 위해 `GET /oneseo/v3/oneseo/me`를 호출하면 인가 단계에서 바로 403이 발생하였습니다.

`POST /oneseo/v3/temp-storage`는 별도의 명시적 권한 규칙이 없어 저장 자체는 성공하지만, 저장된 원서를 조회하는 `GET /oneseo/v3/oneseo/me`만 `ADMIN`에 막혀 있어 "임시저장은 되는데 조회는 안 되는" 현상으로 나타났습니다.

### 변경

- `APPLICANT_OR_ADMIN_OR_ROOT` 권한 상수를 추가하였습니다.
- `/oneseo/v3/oneseo/me`에 대한 `requestMatchers`를 `HttpMethod` 기준으로 분리하였습니다.
  - `GET /oneseo/v3/oneseo/me`: `APPLICANT_OR_ADMIN_OR_ROOT`로 변경하여 `ADMIN`도 조회 가능하도록 허용하였습니다.
  - `POST`, `PUT /oneseo/v3/oneseo/me`: 기존과 동일하게 `APPLICANT_OR_ROOT`를 유지하여 원서 생성/수정 권한 범위는 그대로 두었습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
c: 웬만하면 반영해 주세요. (Comment)
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
