### PR TITLE
[oneseo] 생기부 스캔 파일 업로드용 presigned URL 발급 API 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoExtractionController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoExtractionController.java
@@ -15,8 +15,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ExtractMiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ExtractedAchievementResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrDownloadUrlResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrUploadUrlResDto;
 import team.themoment.hellogsmv3.domain.oneseo.service.ExtractMiddleSchoolAchievementService;
+import team.themoment.hellogsmv3.domain.oneseo.service.IssueOcrDownloadUrlService;
 import team.themoment.hellogsmv3.domain.oneseo.service.IssueOcrUploadUrlService;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
 
@@ -28,6 +30,7 @@ public class OneseoExtractionController {
 
     private final ExtractMiddleSchoolAchievementService extractMiddleSchoolAchievementService;
     private final IssueOcrUploadUrlService issueOcrUploadUrlService;
+    private final IssueOcrDownloadUrlService issueOcrDownloadUrlService;
 
     @Operation(summary = "생활기록부 성적 추출", description = "클라이언트가 생활기록부에서 뽑아 보낸 텍스트를 중학교 성적으로 구조화합니다. 원본 파일은 서버로 전송되지 않으며, 원서 데이터를 수정하지 않습니다. 추출 결과는 사용자가 검토한 뒤 원서 등록 API로 제출해야 합니다.")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "추출 성공"),
@@ -48,5 +51,16 @@ public class OneseoExtractionController {
             @Parameter(description = "업로드할 파일의 확장자 (pdf, jpg, jpeg, png)") @RequestParam String fileExtension,
             @AuthRequest Long memberId) {
         return issueOcrUploadUrlService.execute(memberId, fileExtension);
+    }
+
+    @Operation(summary = "생활기록부 스캔 파일 다운로드용 Presigned URL 발급", description = "OCR 실행 직전 서버에서 S3에 업로드된 스캔 파일을 내려받기 위해 호출합니다. objectKey가 요청자 소유가 아니거나 파일이 존재하지 않으면 오류를 반환합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "발급 성공"),
+            @ApiResponse(responseCode = "403", description = "본인 소유가 아닌 objectKey인 경우"),
+            @ApiResponse(responseCode = "404", description = "파일이 존재하지 않거나 만료된 경우")})
+    @PostMapping("/middle-school-achievement/ocr-download-url")
+    public OcrDownloadUrlResDto issueOcrDownloadUrl(
+            @Parameter(description = "다운로드할 파일의 objectKey") @RequestParam String objectKey,
+            @AuthRequest Long memberId) {
+        return issueOcrDownloadUrlService.execute(memberId, objectKey);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoExtractionController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoExtractionController.java
@@ -3,9 +3,11 @@ package team.themoment.hellogsmv3.domain.oneseo.controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,10 +15,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ExtractMiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ExtractedAchievementResDto;
-import team.themoment.hellogsmv3.domain.oneseo.service.AuthorizeOcrService;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrUploadUrlResDto;
 import team.themoment.hellogsmv3.domain.oneseo.service.ExtractMiddleSchoolAchievementService;
+import team.themoment.hellogsmv3.domain.oneseo.service.IssueOcrUploadUrlService;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
-import team.themoment.sdk.response.CommonApiResponse;
 
 @Tag(name = "Oneseo Extraction API", description = "생활기록부 성적 추출 관련 API입니다.")
 @RestController
@@ -25,7 +27,7 @@ import team.themoment.sdk.response.CommonApiResponse;
 public class OneseoExtractionController {
 
     private final ExtractMiddleSchoolAchievementService extractMiddleSchoolAchievementService;
-    private final AuthorizeOcrService authorizeOcrService;
+    private final IssueOcrUploadUrlService issueOcrUploadUrlService;
 
     @Operation(summary = "생활기록부 성적 추출", description = "클라이언트가 생활기록부에서 뽑아 보낸 텍스트를 중학교 성적으로 구조화합니다. 원본 파일은 서버로 전송되지 않으며, 원서 데이터를 수정하지 않습니다. 추출 결과는 사용자가 검토한 뒤 원서 등록 API로 제출해야 합니다.")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "추출 성공"),
@@ -37,12 +39,14 @@ public class OneseoExtractionController {
         return extractMiddleSchoolAchievementService.execute(reqDto, memberId);
     }
 
-    @Operation(summary = "생활기록부 스캔 페이지 OCR 실행 인증", description = "프론트가 kordoc OCR을 실행하기 직전에 호출합니다. 로그인 여부는 인증 필터에서 걸러지고, 이 API는 회원별 OCR 요청 횟수 제한을 확인합니다. 통과해야만 프론트가 OCR을 실행합니다.")
-    @ApiResponses({@ApiResponse(responseCode = "200", description = "인증 통과"),
+    @Operation(summary = "생활기록부 스캔 파일 업로드용 Presigned URL 발급", description = "프론트가 kordoc OCR을 실행하기 전, 생활기록부 스캔 파일을 S3에 직접 업로드하기 위해 호출합니다. 이 API는 회원별 OCR 요청 횟수 제한을 확인한 뒤 통과 시에만 Presigned URL을 발급합니다. 발급받은 URL로 파일을 S3에 직접 업로드하고, 이후 OCR 실행 요청에는 파일 대신 objectKey를 전달해야 합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "발급 성공"),
+            @ApiResponse(responseCode = "400", description = "지원하지 않는 파일 확장자인 경우"),
             @ApiResponse(responseCode = "429", description = "최근 OCR 요청이 너무 많은 경우")})
-    @PostMapping("/middle-school-achievement/ocr-authorize")
-    public CommonApiResponse authorizeOcr(@AuthRequest Long memberId) {
-        authorizeOcrService.execute(memberId);
-        return CommonApiResponse.success("인증되었습니다.");
+    @PostMapping("/middle-school-achievement/ocr-upload-url")
+    public OcrUploadUrlResDto issueOcrUploadUrl(
+            @Parameter(description = "업로드할 파일의 확장자 (pdf, jpg, jpeg, png)") @RequestParam String fileExtension,
+            @AuthRequest Long memberId) {
+        return issueOcrUploadUrlService.execute(memberId, fileExtension);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/OcrDownloadUrlResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/OcrDownloadUrlResDto.java
@@ -1,0 +1,4 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.response;
+
+public record OcrDownloadUrlResDto(String downloadUrl) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/OcrUploadUrlResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/OcrUploadUrlResDto.java
@@ -1,0 +1,4 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.response;
+
+public record OcrUploadUrlResDto(String uploadUrl, String objectKey) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrDownloadUrlService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrDownloadUrlService.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrDownloadUrlResDto;
@@ -18,6 +19,7 @@ public class IssueOcrDownloadUrlService {
 
     private static final String OBJECT_KEY_PREFIX = "ocr-uploads/";
     private static final Duration DOWNLOAD_URL_EXPIRATION = Duration.ofMinutes(1);
+    private static final long MAX_OBJECT_SIZE_BYTES = 30L * 1024 * 1024;
 
     private final S3Template s3Template;
     private final S3Environment s3Environment;
@@ -28,8 +30,15 @@ public class IssueOcrDownloadUrlService {
             throw new ExpectedException("접근할 수 없는 파일입니다.", HttpStatus.FORBIDDEN);
         }
 
-        if (!s3Template.objectExists(s3Environment.bucketName(), objectKey)) {
+        S3Resource resource = s3Template.createResource(s3Environment.bucketName(), objectKey);
+        if (!resource.exists()) {
             throw new ExpectedException("존재하지 않거나 만료된 파일입니다. objectKey: " + objectKey, HttpStatus.NOT_FOUND);
+        }
+
+        if (resource.contentLength() > MAX_OBJECT_SIZE_BYTES) {
+            s3Template.deleteObject(s3Environment.bucketName(), objectKey);
+            throw new ExpectedException("업로드 가능한 최대 용량(30MB)을 초과한 파일입니다. objectKey: " + objectKey,
+                    HttpStatus.CONTENT_TOO_LARGE);
         }
 
         URL downloadUrl = s3Template.createSignedGetURL(s3Environment.bucketName(), objectKey, DOWNLOAD_URL_EXPIRATION);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrDownloadUrlService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrDownloadUrlService.java
@@ -1,0 +1,39 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import java.net.URL;
+import java.time.Duration;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrDownloadUrlResDto;
+import team.themoment.hellogsmv3.global.thirdParty.aws.s3.data.S3Environment;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class IssueOcrDownloadUrlService {
+
+    private static final String OBJECT_KEY_PREFIX = "ocr-uploads/";
+    private static final Duration DOWNLOAD_URL_EXPIRATION = Duration.ofMinutes(1);
+
+    private final S3Template s3Template;
+    private final S3Environment s3Environment;
+
+    public OcrDownloadUrlResDto execute(Long memberId, String objectKey) {
+        String ownedPrefix = OBJECT_KEY_PREFIX + memberId + "/";
+        if (!objectKey.startsWith(ownedPrefix)) {
+            throw new ExpectedException("접근할 수 없는 파일입니다.", HttpStatus.FORBIDDEN);
+        }
+
+        if (!s3Template.objectExists(s3Environment.bucketName(), objectKey)) {
+            throw new ExpectedException("존재하지 않거나 만료된 파일입니다. objectKey: " + objectKey, HttpStatus.NOT_FOUND);
+        }
+
+        URL downloadUrl = s3Template.createSignedGetURL(s3Environment.bucketName(), objectKey, DOWNLOAD_URL_EXPIRATION);
+
+        return new OcrDownloadUrlResDto(downloadUrl.toString());
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrUploadUrlService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrUploadUrlService.java
@@ -1,0 +1,42 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrUploadUrlResDto;
+import team.themoment.hellogsmv3.global.thirdParty.aws.s3.data.S3Environment;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class IssueOcrUploadUrlService {
+
+    private static final String OBJECT_KEY_PREFIX = "ocr-uploads/";
+    private static final Duration UPLOAD_URL_EXPIRATION = Duration.ofMinutes(5);
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("pdf", "jpg", "jpeg", "png");
+
+    private final AuthorizeOcrService authorizeOcrService;
+    private final S3Template s3Template;
+    private final S3Environment s3Environment;
+
+    public OcrUploadUrlResDto execute(Long memberId, String fileExtension) {
+        authorizeOcrService.execute(memberId);
+
+        String normalizedExtension = fileExtension.toLowerCase();
+        if (!ALLOWED_EXTENSIONS.contains(normalizedExtension)) {
+            throw new ExpectedException("지원하지 않는 파일 확장자입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        String objectKey = OBJECT_KEY_PREFIX + memberId + "/" + UUID.randomUUID() + "." + normalizedExtension;
+        URL uploadUrl = s3Template.createSignedPutURL(s3Environment.bucketName(), objectKey, UPLOAD_URL_EXPIRATION);
+
+        return new OcrUploadUrlResDto(uploadUrl.toString(), objectKey);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrUploadUrlService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrUploadUrlService.java
@@ -27,12 +27,12 @@ public class IssueOcrUploadUrlService {
     private final S3Environment s3Environment;
 
     public OcrUploadUrlResDto execute(Long memberId, String fileExtension) {
-        authorizeOcrService.execute(memberId);
-
         String normalizedExtension = fileExtension.toLowerCase();
         if (!ALLOWED_EXTENSIONS.contains(normalizedExtension)) {
             throw new ExpectedException("지원하지 않는 파일 확장자입니다.", HttpStatus.BAD_REQUEST);
         }
+
+        authorizeOcrService.execute(memberId);
 
         String objectKey = OBJECT_KEY_PREFIX + memberId + "/" + UUID.randomUUID() + "." + normalizedExtension;
         URL uploadUrl = s3Template.createSignedPutURL(s3Environment.bucketName(), objectKey, UPLOAD_URL_EXPIRATION);

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrDownloadUrlServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrDownloadUrlServiceTest.java
@@ -1,0 +1,102 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import io.awspring.cloud.s3.S3Template;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrDownloadUrlResDto;
+import team.themoment.hellogsmv3.global.thirdParty.aws.s3.data.S3Environment;
+import team.themoment.sdk.exception.ExpectedException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OCR 다운로드 URL 발급 서비스 테스트")
+class IssueOcrDownloadUrlServiceTest {
+
+    @Mock
+    private S3Template s3Template;
+
+    private IssueOcrDownloadUrlService service;
+
+    @BeforeEach
+    void setUp() {
+        S3Environment s3Environment = new S3Environment("hello-test-bucket");
+        service = new IssueOcrDownloadUrlService(s3Template, s3Environment);
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("요청자 소유의 objectKey이고 파일이 존재하는 경우")
+        class Context_with_owned_and_existing_object_key {
+
+            @Test
+            @DisplayName("presigned GET URL을 발급한다")
+            void it_issues_presigned_url() throws MalformedURLException {
+                String objectKey = "ocr-uploads/1/test.pdf";
+                URL signedUrl = URI.create("https://hello-test-bucket.s3.amazonaws.com/" + objectKey).toURL();
+                given(s3Template.objectExists("hello-test-bucket", objectKey)).willReturn(true);
+                given(s3Template.createSignedGetURL(eq("hello-test-bucket"), eq(objectKey), eq(Duration.ofMinutes(1))))
+                        .willReturn(signedUrl);
+
+                OcrDownloadUrlResDto result = service.execute(1L, objectKey);
+
+                assertThat(result.downloadUrl()).isEqualTo(signedUrl.toString());
+            }
+        }
+
+        @Nested
+        @DisplayName("다른 회원 소유의 objectKey가 주어진 경우")
+        class Context_with_not_owned_object_key {
+
+            @Test
+            @DisplayName("ExpectedException(403)을 던진다")
+            void it_throws_forbidden() {
+                String objectKey = "ocr-uploads/2/test.pdf";
+
+                assertThatThrownBy(() -> service.execute(1L, objectKey)).isInstanceOf(ExpectedException.class)
+                        .extracting(e -> ((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+
+                verify(s3Template, never()).objectExists(any(), any());
+                verify(s3Template, never()).createSignedGetURL(any(), any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 objectKey가 주어진 경우")
+        class Context_with_non_existing_object_key {
+
+            @Test
+            @DisplayName("ExpectedException(404)을 던진다")
+            void it_throws_not_found() {
+                String objectKey = "ocr-uploads/1/missing.pdf";
+                given(s3Template.objectExists("hello-test-bucket", objectKey)).willReturn(false);
+
+                assertThatThrownBy(() -> service.execute(1L, objectKey)).isInstanceOf(ExpectedException.class)
+                        .extracting(e -> ((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+
+                verify(s3Template, never()).createSignedGetURL(any(), any(), any());
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrDownloadUrlServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrDownloadUrlServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -22,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
+import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrDownloadUrlResDto;
 import team.themoment.hellogsmv3.global.thirdParty.aws.s3.data.S3Environment;
@@ -47,15 +49,18 @@ class IssueOcrDownloadUrlServiceTest {
     class Describe_execute {
 
         @Nested
-        @DisplayName("요청자 소유의 objectKey이고 파일이 존재하는 경우")
-        class Context_with_owned_and_existing_object_key {
+        @DisplayName("요청자 소유의 objectKey이고 파일이 존재하며 용량이 허용 범위인 경우")
+        class Context_with_owned_existing_and_valid_size_object_key {
 
             @Test
             @DisplayName("presigned GET URL을 발급한다")
             void it_issues_presigned_url() throws MalformedURLException {
                 String objectKey = "ocr-uploads/1/test.pdf";
                 URL signedUrl = URI.create("https://hello-test-bucket.s3.amazonaws.com/" + objectKey).toURL();
-                given(s3Template.objectExists("hello-test-bucket", objectKey)).willReturn(true);
+                S3Resource resource = mock(S3Resource.class);
+                given(resource.exists()).willReturn(true);
+                given(resource.contentLength()).willReturn(10L * 1024 * 1024);
+                given(s3Template.createResource("hello-test-bucket", objectKey)).willReturn(resource);
                 given(s3Template.createSignedGetURL(eq("hello-test-bucket"), eq(objectKey), eq(Duration.ofMinutes(1))))
                         .willReturn(signedUrl);
 
@@ -77,7 +82,7 @@ class IssueOcrDownloadUrlServiceTest {
                 assertThatThrownBy(() -> service.execute(1L, objectKey)).isInstanceOf(ExpectedException.class)
                         .extracting(e -> ((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 
-                verify(s3Template, never()).objectExists(any(), any());
+                verify(s3Template, never()).createResource(any(), any());
                 verify(s3Template, never()).createSignedGetURL(any(), any(), any());
             }
         }
@@ -90,11 +95,35 @@ class IssueOcrDownloadUrlServiceTest {
             @DisplayName("ExpectedException(404)을 던진다")
             void it_throws_not_found() {
                 String objectKey = "ocr-uploads/1/missing.pdf";
-                given(s3Template.objectExists("hello-test-bucket", objectKey)).willReturn(false);
+                S3Resource resource = mock(S3Resource.class);
+                given(resource.exists()).willReturn(false);
+                given(s3Template.createResource("hello-test-bucket", objectKey)).willReturn(resource);
 
                 assertThatThrownBy(() -> service.execute(1L, objectKey)).isInstanceOf(ExpectedException.class)
                         .extracting(e -> ((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 
+                verify(s3Template, never()).createSignedGetURL(any(), any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("업로드된 파일이 허용 용량(30MB)을 초과한 경우")
+        class Context_with_oversized_object {
+
+            @Test
+            @DisplayName("파일을 삭제하고 ExpectedException(413)을 던진다")
+            void it_deletes_object_and_throws_payload_too_large() {
+                String objectKey = "ocr-uploads/1/huge.pdf";
+                S3Resource resource = mock(S3Resource.class);
+                given(resource.exists()).willReturn(true);
+                given(resource.contentLength()).willReturn(31L * 1024 * 1024);
+                given(s3Template.createResource("hello-test-bucket", objectKey)).willReturn(resource);
+
+                assertThatThrownBy(() -> service.execute(1L, objectKey)).isInstanceOf(ExpectedException.class)
+                        .extracting(e -> ((ExpectedException) e).getStatusCode())
+                        .isEqualTo(HttpStatus.CONTENT_TOO_LARGE);
+
+                verify(s3Template).deleteObject("hello-test-bucket", objectKey);
                 verify(s3Template, never()).createSignedGetURL(any(), any(), any());
             }
         }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrUploadUrlServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrUploadUrlServiceTest.java
@@ -1,0 +1,103 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import io.awspring.cloud.s3.S3Template;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OcrUploadUrlResDto;
+import team.themoment.hellogsmv3.global.thirdParty.aws.s3.data.S3Environment;
+import team.themoment.sdk.exception.ExpectedException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OCR 업로드 URL 발급 서비스 테스트")
+class IssueOcrUploadUrlServiceTest {
+
+    @Mock
+    private AuthorizeOcrService authorizeOcrService;
+
+    @Mock
+    private S3Template s3Template;
+
+    private IssueOcrUploadUrlService service;
+
+    @BeforeEach
+    void setUp() throws MalformedURLException {
+        S3Environment s3Environment = new S3Environment("hello-test-bucket");
+        service = new IssueOcrUploadUrlService(authorizeOcrService, s3Template, s3Environment);
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("허용된 확장자가 주어진 경우")
+        class Context_with_allowed_extension {
+
+            @Test
+            @DisplayName("rate limit을 확인한 뒤 presigned URL을 발급한다")
+            void it_issues_presigned_url() throws MalformedURLException {
+                URL signedUrl = URI.create("https://hello-test-bucket.s3.amazonaws.com/ocr-uploads/1/test.pdf").toURL();
+                given(s3Template.createSignedPutURL(eq("hello-test-bucket"), any(), eq(Duration.ofMinutes(5))))
+                        .willReturn(signedUrl);
+
+                OcrUploadUrlResDto result = service.execute(1L, "pdf");
+
+                verify(authorizeOcrService).execute(1L);
+                assertThat(result.uploadUrl()).isEqualTo(signedUrl.toString());
+                assertThat(result.objectKey()).startsWith("ocr-uploads/1/").endsWith(".pdf");
+            }
+        }
+
+        @Nested
+        @DisplayName("허용되지 않은 확장자가 주어진 경우")
+        class Context_with_disallowed_extension {
+
+            @Test
+            @DisplayName("ExpectedException(400)을 던진다")
+            void it_throws_bad_request() {
+                assertThatThrownBy(() -> service.execute(1L, "exe")).isInstanceOf(ExpectedException.class)
+                        .extracting(e -> ((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+                verify(authorizeOcrService).execute(1L);
+                verify(s3Template, never()).createSignedPutURL(any(), any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("OCR 요청 횟수 제한을 초과한 경우")
+        class Context_over_rate_limit {
+
+            @Test
+            @DisplayName("presigned URL을 발급하지 않고 예외를 전파한다")
+            void it_propagates_exception_without_issuing_url() {
+                ExpectedException rateLimitException = new ExpectedException("OCR 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
+                        HttpStatus.TOO_MANY_REQUESTS);
+                org.mockito.BDDMockito.willThrow(rateLimitException).given(authorizeOcrService).execute(1L);
+
+                assertThatThrownBy(() -> service.execute(1L, "pdf")).isSameAs(rateLimitException);
+
+                verify(s3Template, never()).createSignedPutURL(any(), any(), any());
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrUploadUrlServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/IssueOcrUploadUrlServiceTest.java
@@ -73,12 +73,12 @@ class IssueOcrUploadUrlServiceTest {
         class Context_with_disallowed_extension {
 
             @Test
-            @DisplayName("ExpectedException(400)을 던진다")
+            @DisplayName("rate limit을 소모하지 않고 ExpectedException(400)을 던진다")
             void it_throws_bad_request() {
                 assertThatThrownBy(() -> service.execute(1L, "exe")).isInstanceOf(ExpectedException.class)
                         .extracting(e -> ((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
 
-                verify(authorizeOcrService).execute(1L);
+                verify(authorizeOcrService, never()).execute(any());
                 verify(s3Template, never()).createSignedPutURL(any(), any(), any());
             }
         }


### PR DESCRIPTION
## 배경

프론트에서 OCR 기능 테스트 중 413이 확인됐고, 프론트가 분석한 원인은 다음과 같습니다:

- `feat/school-record-ocr-autofill`의 OCR 실행 Next.js API Route는 `export const runtime = 'nodejs'`로 동작하는 Vercel Serverless Function
- Vercel Serverless Function은 요청 본문(request body) 크기를 4.5MB로 하드 캡 — `vercel.json`이나 코드로 늘릴 수 없는 플랫폼 레벨 제한
- 로컬 Next.js dev 서버에는 이 제한이 없어 20MB짜리 PDF도 통과되지만, 배포 환경(Vercel)에서는 정부24 생기부 PDF(스캔 이미지 포함, 몇 MB는 쉽게 넘음)가 라우트 핸들러에 도달하기도 전에 413으로 차단됨

세 가지 해결 방향(제한값 하향/클라이언트 압축/직접 업로드) 중, 실사용 PDF 대부분이 4.5MB를 넘는 상황에서 UX 저하 없이 근본적으로 해결하는 방법은 **클라이언트가 파일을 서버리스 함수를 거치지 않고 스토리지에 직접 업로드**하는 것으로 판단했습니다.

## 변경 사항

- 기존 `POST /oneseo/v3/extraction/middle-school-achievement/ocr-authorize`(rate limit만 체크하고 성공 메시지만 반환)를 `POST /oneseo/v3/extraction/middle-school-achievement/ocr-upload-url`로 대체
  - rate limit 체크(`AuthorizeOcrService`, 기존 로직 그대로 재사용)는 유지
  - 통과 시 S3 presigned PUT URL과 objectKey를 `{ uploadUrl, objectKey }`로 반환 (`IssueOcrUploadUrlService`)
  - presigned URL 만료 5분, 파일 확장자 화이트리스트(pdf/jpg/jpeg/png) 검증
  - 기존 `UploadImageService`가 쓰던 `S3Template`/`S3Environment` 빈을 그대로 재사용 — 별도 인프라 추가 없음

## 프론트 연동 방식 (참고)

1. 프론트 → 백엔드: `POST .../ocr-upload-url?fileExtension=pdf` 호출 → `{ uploadUrl, objectKey }` 수신
2. 프론트 → S3: 수신한 `uploadUrl`로 파일을 직접 PUT 업로드 (Vercel 4.5MB 제한과 무관)
3. 프론트 → OCR 실행 Route: 파일 본문 대신 `objectKey`만 전달, Route가 서버 사이드로 S3에서 파일을 내려받아 kordoc 실행

`ocr-upload-url`을 호출하는 프론트 코드가 아직 없어(관련 브랜치 미푸시 확인) 기존 엔드포인트 계약을 바꿔도 영향 없습니다.

## 검증

- 단위 테스트 3건(정상 발급 / 허용되지 않은 확장자 시 400 / rate limit 초과 시 URL 미발급) 통과
- 전체 테스트 스위트 통과
