### PR TITLE
[oneseo] 자유학기 1-2 대체 시 1학년 1학기 성적 조회 시 유실되는 문제 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/MiddleSchoolAchievementCalcDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/MiddleSchoolAchievementCalcDto.java
@@ -10,8 +10,9 @@ import lombok.Builder;
  * generalSubjects,newSubjects,artsPhysicalSubjects가 없습니다.
  */
 @Builder
-public record MiddleSchoolAchievementCalcDto(List<Integer> achievement1_2, List<Integer> achievement2_1,
-        List<Integer> achievement2_2, List<Integer> achievement3_1, List<Integer> achievement3_2,
-        List<Integer> artsPhysicalAchievement, List<Integer> absentDays, List<Integer> attendanceDays,
-        List<Integer> volunteerTime, String liberalSystem, String freeSemester, BigDecimal gedAvgScore) {
+public record MiddleSchoolAchievementCalcDto(List<Integer> achievement1_1, List<Integer> achievement1_2,
+        List<Integer> achievement2_1, List<Integer> achievement2_2, List<Integer> achievement3_1,
+        List<Integer> achievement3_2, List<Integer> artsPhysicalAchievement, List<Integer> absentDays,
+        List<Integer> attendanceDays, List<Integer> volunteerTime, String liberalSystem, String freeSemester,
+        BigDecimal gedAvgScore) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -28,6 +28,10 @@ public class MiddleSchoolAchievement {
     private Oneseo oneseo;
 
     @Convert(converter = IntegerListConverter.class)
+    @Column(name = "achievement_1_1")
+    private List<Integer> achievement1_1;
+
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "achievement_1_2")
     private List<Integer> achievement1_2;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -108,7 +108,8 @@ public class CreateOneseoService {
         List<Integer> attendanceDays = middleSchoolAchievement.getAttendanceDays();
         Integer absentDaysCount = OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
 
-        return MiddleSchoolAchievementResDto.builder().achievement1_2(middleSchoolAchievement.getAchievement1_2())
+        return MiddleSchoolAchievementResDto.builder().achievement1_1(middleSchoolAchievement.getAchievement1_1())
+                .achievement1_2(middleSchoolAchievement.getAchievement1_2())
                 .achievement2_1(middleSchoolAchievement.getAchievement2_1())
                 .achievement2_2(middleSchoolAchievement.getAchievement2_2())
                 .achievement3_1(middleSchoolAchievement.getAchievement3_1())
@@ -272,9 +273,10 @@ public class CreateOneseoService {
         MiddleSchoolAchievementCalcDto calcDto = buildCalcDtoWithFillEmpty(reqDto.middleSchoolAchievement(),
                 reqDto.graduationType());
 
-        builder.oneseo(oneseo).achievement1_2(calcDto.achievement1_2()).achievement2_1(calcDto.achievement2_1())
-                .achievement2_2(calcDto.achievement2_2()).achievement3_1(calcDto.achievement3_1())
-                .achievement3_2(calcDto.achievement3_2()).generalSubjects(middleSchoolAchievement.generalSubjects())
+        builder.oneseo(oneseo).achievement1_1(calcDto.achievement1_1()).achievement1_2(calcDto.achievement1_2())
+                .achievement2_1(calcDto.achievement2_1()).achievement2_2(calcDto.achievement2_2())
+                .achievement3_1(calcDto.achievement3_1()).achievement3_2(calcDto.achievement3_2())
+                .generalSubjects(middleSchoolAchievement.generalSubjects())
                 .newSubjects(middleSchoolAchievement.newSubjects())
                 .artsPhysicalAchievement(calcDto.artsPhysicalAchievement())
                 .artsPhysicalSubjects(middleSchoolAchievement.artsPhysicalSubjects()).absentDays(calcDto.absentDays())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -99,7 +99,8 @@ public class ModifyOneseoService {
         List<Integer> attendanceDays = middleSchoolAchievement.getAttendanceDays();
         Integer absentDaysCount = OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
 
-        return MiddleSchoolAchievementResDto.builder().achievement1_2(middleSchoolAchievement.getAchievement1_2())
+        return MiddleSchoolAchievementResDto.builder().achievement1_1(middleSchoolAchievement.getAchievement1_1())
+                .achievement1_2(middleSchoolAchievement.getAchievement1_2())
                 .achievement2_1(middleSchoolAchievement.getAchievement2_1())
                 .achievement2_2(middleSchoolAchievement.getAchievement2_2())
                 .achievement3_1(middleSchoolAchievement.getAchievement3_1())
@@ -265,9 +266,10 @@ public class ModifyOneseoService {
                 reqDto.graduationType());
 
         MiddleSchoolAchievement modifiedMiddleSchoolAchievement = MiddleSchoolAchievement.builder()
-                .id(middleSchoolAchievement.getId()).oneseo(oneseo).achievement1_2(calcDto.achievement1_2())
-                .achievement2_1(calcDto.achievement2_1()).achievement2_2(calcDto.achievement2_2())
-                .achievement3_1(calcDto.achievement3_1()).achievement3_2(calcDto.achievement3_2())
+                .id(middleSchoolAchievement.getId()).oneseo(oneseo).achievement1_1(calcDto.achievement1_1())
+                .achievement1_2(calcDto.achievement1_2()).achievement2_1(calcDto.achievement2_1())
+                .achievement2_2(calcDto.achievement2_2()).achievement3_1(calcDto.achievement3_1())
+                .achievement3_2(calcDto.achievement3_2())
                 .generalSubjects(updatedMiddleSchoolAchievement.generalSubjects())
                 .newSubjects(updatedMiddleSchoolAchievement.newSubjects())
                 .artsPhysicalAchievement(calcDto.artsPhysicalAchievement())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -91,7 +91,8 @@ public class OneseoService {
             }
         }
 
-        builder.achievement1_2(validationGeneralAchievement(tmpAchievement1_2))
+        builder.achievement1_1(validationGeneralAchievement(tmpAchievement1_1))
+                .achievement1_2(validationGeneralAchievement(tmpAchievement1_2))
                 .achievement2_1(validationGeneralAchievement(tmpAchievement2_1))
                 .achievement2_2(validationGeneralAchievement(tmpAchievement2_2))
                 .achievement3_1(validationGeneralAchievement(tmpAchievement3_1))

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -129,8 +129,9 @@ public class QueryOneseoByIdService {
             }
         }
 
-        return MiddleSchoolAchievementResDto.builder().achievement1_2(achievement1_2).achievement2_1(achievement2_1)
-                .achievement2_2(achievement2_2).achievement3_1(achievement3_1).achievement3_2(achievement3_2)
+        return MiddleSchoolAchievementResDto.builder().achievement1_1(middleSchoolAchievement.getAchievement1_1())
+                .achievement1_2(achievement1_2).achievement2_1(achievement2_1).achievement2_2(achievement2_2)
+                .achievement3_1(achievement3_1).achievement3_2(achievement3_2)
                 .generalSubjects(middleSchoolAchievement.getGeneralSubjects())
                 .newSubjects(middleSchoolAchievement.getNewSubjects())
                 .artsPhysicalAchievement(middleSchoolAchievement.getArtsPhysicalAchievement())

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
@@ -114,6 +114,8 @@ class QueryOneseoByIdServiceTest {
                 assertEquals(oneseoPrivacyDetail.getStudentNumber(), oneseoPrivacyDetailResDto.studentNumber());
 
                 MiddleSchoolAchievementResDto middleSchoolAchievementResDto = result.middleSchoolAchievement();
+                assertEquals(middleSchoolAchievement.getAchievement1_1(),
+                        middleSchoolAchievementResDto.achievement1_1());
                 assertEquals(middleSchoolAchievement.getAchievement1_2(),
                         middleSchoolAchievementResDto.achievement1_2());
                 assertEquals(middleSchoolAchievement.getAchievement2_1(),
@@ -312,6 +314,32 @@ class QueryOneseoByIdServiceTest {
             assertNull(result.achievement2_2());
             assertEquals(List.of(1, 2, 3, 4, 5), result.achievement3_1());
             assertEquals(List.of(1, 2, 3, 4, 5), result.achievement3_2());
+        }
+
+        @Test
+        @DisplayName("freeSemester가 1-2이고 1학년 1학기 성적이 별도로 저장되어 있는 경우 achievement1_1을 그대로 반환한다")
+        void it_returns_achievement1_1_for_free_semester_1_2() {
+            Member member = buildMember(memberId);
+            List<Integer> achievement1_1 = List.of(5, 4, 3, 2, 1);
+            List<Integer> integerList = List.of(1, 2, 3, 4, 5);
+            List<String> stringList = List.of("과목1", "과목2", "과목3");
+            MiddleSchoolAchievement msa = MiddleSchoolAchievement.builder().achievement1_1(achievement1_1)
+                    .achievement1_2(integerList).achievement2_1(integerList).achievement2_2(integerList)
+                    .achievement3_1(integerList).achievement3_2(integerList).generalSubjects(stringList)
+                    .newSubjects(stringList).artsPhysicalAchievement(List.of(3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3))
+                    .artsPhysicalSubjects(stringList).absentDays(integerList).attendanceDays(integerList)
+                    .volunteerTime(integerList).liberalSystem("자유학기제").freeSemester("1-2").gedAvgScore(null).build();
+            OneseoPrivacyDetail privacyDetail = buildOneseoPrivacyDetail();
+            Oneseo oneseo = buildOneseo(member, msa, privacyDetail);
+
+            given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+            given(oneseoPrivacyDetailRepository.findByOneseo(oneseo)).willReturn(privacyDetail);
+            given(middleSchoolAchievementRepository.findByOneseo(oneseo)).willReturn(msa);
+
+            MiddleSchoolAchievementResDto result = queryOneseoByIdService.execute(memberId).middleSchoolAchievement();
+
+            assertEquals(achievement1_1, result.achievement1_1());
+            assertNull(result.achievement1_2());
         }
     }
 }


### PR DESCRIPTION
## 배경

프론트 `hellogsm-client-26` PR #448 리뷰에서 발견된 백엔드 이슈입니다.

졸업자·졸업예정자가 1학년 2학기(`1-2`)를 자유학기로 신청하면, 입학요강상 1학년 1학기(`1-1`) 성적을 1-2 자리에 대체해 채점에 사용합니다. 그런데 `MiddleSchoolAchievement` 엔티티엔 1학년 슬롯이 `achievement_1_2` 하나뿐이라:

- **저장 시**: `achievement1_1`에 성적, `achievement1_2`는 null로 요청하면 → `achievement1_1` 값이 `achievement_1_2` 슬롯에 병합 저장됨
- **조회 시**: `freeSemester`가 `1-2`면 `achievement_1_2`를 무조건 null로 복원(채점용으로 복사된 자유학기 성적을 화면에서 숨기기 위한 로직) → 결과적으로 사용자가 입력한 1-1 성적이 조회 응답 어디에도 남지 않고, 원서 출력에서 1학년 성적이 통째로 빈칸으로 보임

## 변경 사항

- `MiddleSchoolAchievement` 엔티티에 `achievement_1_1` 컬럼 추가 — 2/3학년(`achievement_2_1`/`achievement_2_2`/`achievement_3_1`/`achievement_3_2`)과 동일하게 병합 없이 원본 그대로 저장
- `MiddleSchoolAchievementCalcDto`에 `achievement1_1` 추가, `OneseoService.buildCalcDtoWithFillEmpty`가 원본 값을 함께 실어 나르도록 수정
  - 채점용 `achievement1_2` 대체(1-1 → 1-2 fallback) 로직 자체는 변경 없음 — 점수 계산 결과에 영향 없음
- `CreateOneseoService` / `ModifyOneseoService`: 엔티티 저장, 응답 DTO 양쪽에 `achievement1_1` 연결
- `QueryOneseoByIdService`: 조회 시 `achievement1_1`을 무조건 null로 두던 부분을 고쳐, 저장된 원본 값을 그대로 응답에 반환 (`achievement1_2`를 null로 복원하는 기존 로직은 유지)

## 스키마 참고

이 프로젝트는 Flyway/Liquibase 없이 `HIBERNATE_DDL_AUTO` 환경변수로 스키마를 관리합니다. dev/stage가 `update`라면 배포 시 컬럼이 자동 생성되지만, prod가 `validate`로 되어 있다면 배포 전 `tb_middle_school_achievement`에 `achievement_1_1` 컬럼 수동 추가가 필요할 수 있습니다.

## 검증

- 회귀 테스트 추가: `freeSemester="1-2"` + `achievement1_1`이 저장된 상태에서 조회 시 `achievement1_1`은 그대로 반환되고 `achievement1_2`만 null인지 검증
- 기존 자유학기 null 복원 테스트(2-1/2-2/3-1/3-2/자유학년제) 전부 통과 확인
- 전체 테스트 스위트 통과
