### PR TITLE
update(operation): 1차 결과 발표 API의 기간 제한 제거

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/controller/OperationTestResultController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/controller/OperationTestResultController.java
@@ -35,7 +35,7 @@ public class OperationTestResultController {
 
     @Operation(summary = "1차 결과 발표", description = "1차 결과를 발표합니다.")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "1차 결과 발표 성공했습니다."),
-            @ApiResponse(responseCode = "400", description = "1차 결과 발표 기간 이전이거나 이미 발표된 상태입니다.", content = @Content())})
+            @ApiResponse(responseCode = "400", description = "아직 입력되지 않은 1차 시험 결과가 있거나 이미 발표된 상태입니다.", content = @Content())})
     @PostMapping("/operation/announce-first-test-result")
     public CommonApiResponse announceFirstTestResult() {
         announceFirstTestResultService.execute();

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultService.java
@@ -2,8 +2,6 @@ package team.themoment.hellogsmv3.domain.common.operation.service;
 
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
-import java.time.LocalDateTime;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 import team.themoment.sdk.exception.ExpectedException;
 
 @Service
@@ -21,11 +18,10 @@ public class AnnounceFirstTestResultService {
 
     private final OperationTestResultRepository operationTestResultRepository;
     private final EntranceTestResultRepository entranceTestResultRepository;
-    private final ScheduleEnvironment scheduleEnv;
 
     @Transactional
     public void execute() {
-        validateFirstTestResultAnnouncementPeriod();
+        validateAllFirstTestResultsExist();
 
         OperationTestResult testResult = operationTestResultRepository.findTestResult()
                 .orElseThrow(() -> new ExpectedException("시험 운영 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
@@ -36,10 +32,9 @@ public class AnnounceFirstTestResultService {
         operationTestResultRepository.save(testResult);
     }
 
-    private void validateFirstTestResultAnnouncementPeriod() {
-        if (LocalDateTime.now().isBefore(scheduleEnv.firstResultsAnnouncement())
-                || entranceTestResultRepository.existsByFirstTestPassYnIsNull()) {
-            throw new ExpectedException("1차 결과 발표 기간 이전에 발표 여부를 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);
+    private void validateAllFirstTestResultsExist() {
+        if (entranceTestResultRepository.existsByFirstTestPassYnIsNull()) {
+            throw new ExpectedException("아직 입력되지 않은 1차 시험 결과가 있습니다.", HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +21,6 @@ import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 import team.themoment.sdk.exception.ExpectedException;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,8 +31,6 @@ class AnnounceFirstTestResultServiceTest {
     private OperationTestResultRepository operationTestResultRepository;
     @Mock
     private EntranceTestResultRepository entranceTestResultRepository;
-    @Mock
-    private ScheduleEnvironment scheduleEnv;
 
     @InjectMocks
     private AnnounceFirstTestResultService announceFirstTestResultService;
@@ -44,12 +40,31 @@ class AnnounceFirstTestResultServiceTest {
     class Describe_execute {
 
         @Nested
+        @DisplayName("아직 입력되지 않은 1차 시험 결과가 있을 경우")
+        class Context_not_all_first_test_results_exist {
+
+            @BeforeEach
+            void setUp() {
+                given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(true);
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> announceFirstTestResultService.execute());
+
+                assertEquals("아직 입력되지 않은 1차 시험 결과가 있습니다.", exception.getMessage());
+                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+            }
+        }
+
+        @Nested
         @DisplayName("시험 운영 정보가 없을 경우")
         class Context_operation_test_result_not_found {
 
             @BeforeEach
             void setUp() {
-                given(scheduleEnv.firstResultsAnnouncement()).willReturn(LocalDateTime.now().minusDays(1));
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(false);
                 given(operationTestResultRepository.findTestResult()).willReturn(Optional.empty());
             }
@@ -66,32 +81,11 @@ class AnnounceFirstTestResultServiceTest {
         }
 
         @Nested
-        @DisplayName("1차 결과 발표 기간 이전일 경우")
-        class Context_before_first_test_result_announcement {
-
-            @BeforeEach
-            void setUp() {
-                given(scheduleEnv.firstResultsAnnouncement()).willReturn(LocalDateTime.now().plusDays(1));
-            }
-
-            @Test
-            @DisplayName("ExpectedException을 던진다")
-            void it_throws_expected_exception() {
-                ExpectedException exception = assertThrows(ExpectedException.class,
-                        () -> announceFirstTestResultService.execute());
-
-                assertEquals("1차 결과 발표 기간 이전에 발표 여부를 수정할 수 없습니다.", exception.getMessage());
-                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-            }
-        }
-
-        @Nested
         @DisplayName("1차 결과가 이미 발표된 경우")
         class Context_first_test_already_announced {
 
             @BeforeEach
             void setUp() {
-                given(scheduleEnv.firstResultsAnnouncement()).willReturn(LocalDateTime.now().minusDays(1));
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(false);
 
                 OperationTestResult testResult = mock(OperationTestResult.class);
@@ -120,7 +114,6 @@ class AnnounceFirstTestResultServiceTest {
             @BeforeEach
             void setUp() {
                 testResult = mock(OperationTestResult.class);
-                given(scheduleEnv.firstResultsAnnouncement()).willReturn(LocalDateTime.now().minusDays(1));
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(false);
                 given(testResult.getFirstTestResultAnnouncementYn()).willReturn(NO);
                 given(operationTestResultRepository.findTestResult()).willReturn(Optional.of(testResult));


### PR DESCRIPTION
## 개요

1차 결과 발표 API(`POST /operation/v3/operation/announce-first-test-result`)에 걸려있던 발표 기간 제한을 제거했습니다.

## 본문

- `AnnounceFirstTestResultService`에서 `scheduleEnv.firstResultsAnnouncement()` 기준으로 현재 시각이 발표 기간 이전이면 막던 검증 로직을 제거했습니다.
- 1차 시험 결과가 아직 전부 입력되지 않았을 때 발표를 막는 검증(`existsByFirstTestPassYnIsNull`)은 기간 제한이 아닌 데이터 정합성 검증이므로 유지했습니다.
- 더 이상 사용되지 않는 `ScheduleEnvironment` 의존성과 관련 import를 제거했습니다.
- 컨트롤러의 Swagger 400 응답 설명을 실제 동작에 맞게 수정했습니다.

### 변경 - optional

- `AnnounceFirstTestResultServiceTest`의 "기간 이전" 테스트 케이스를 제거하고, "미입력 시험 결과 존재" 케이스로 대체했습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
c: 웬만하면 반영해 주세요. (Comment)
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)

https://claude.ai/code/session_01GSeHDiR1U7GyrsUUihpGg3