### PR TITLE
[oneseo] 임시저장 시 성적이 빈 객체면 점수 계산을 건너뛰도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -77,6 +77,9 @@ public class OneseoTempStorageService {
 
     private MiddleSchoolAchievementResDto buildMiddleSchoolAchievementResDto(OneseoTempReqDto reqDto) {
         MiddleSchoolAchievementReqDto middleSchoolAchievement = reqDto.middleSchoolAchievement();
+        if (middleSchoolAchievement == null) {
+            return MiddleSchoolAchievementResDto.builder().build();
+        }
 
         List<Integer> absentDays = middleSchoolAchievement.absentDays();
         List<Integer> attendanceDays = middleSchoolAchievement.attendanceDays();

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -30,6 +30,9 @@ import team.themoment.sdk.exception.ExpectedException;
 @RequiredArgsConstructor
 public class OneseoTempStorageService {
 
+    private static final MiddleSchoolAchievementReqDto EMPTY_ACHIEVEMENT = MiddleSchoolAchievementReqDto.builder()
+            .build();
+
     private final MemberService memberService;
     private final OneseoRepository oneseoRepository;
     private final LambdaScoreCalculatorClient lambdaScoreCalculatorClient;
@@ -97,7 +100,7 @@ public class OneseoTempStorageService {
 
     private CalculatedScoreResDto calculateScore(OneseoTempReqDto reqDto) {
         MiddleSchoolAchievementReqDto achievement = reqDto.middleSchoolAchievement();
-        if (achievement == null) {
+        if (achievement == null || achievement.equals(EMPTY_ACHIEVEMENT)) {
             return null;
         }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
@@ -192,6 +192,31 @@ class OneseoTempStorageServiceTest {
             }
 
             @Nested
+            @DisplayName("middleSchoolAchievement가 null로 주어지면")
+            class Context_with_null_middle_school_achievement {
+                private final OneseoTempReqDto nullAchievementReqDto = OneseoTempReqDto.builder()
+                        .graduationType(GraduationType.GED).graduationDate("2026-01").address("광주광역시 광산구 송정동 상무대로 312")
+                        .detailAddress("101동 1001호").profileImg("https://example.com/image.jpg")
+                        .middleSchoolAchievement(null).firstDesiredMajor(Major.SW).secondDesiredMajor(Major.AI)
+                        .thirdDesiredMajor(Major.IOT).build();
+
+                @BeforeEach
+                void setUp() {
+                    given(oneseoRepository.findByMember(member)).willReturn(Optional.empty());
+                }
+
+                @Test
+                @DisplayName("NPE 없이 Lambda 점수 계산을 호출하지 않고 calculatedScore로 null을 반환한다")
+                void it_skips_lambda_call_and_returns_null_calculated_score() {
+                    FoundOneseoResDto result = oneseoTempStorageService.execute(nullAchievementReqDto, step, memberId);
+
+                    assertNull(result.middleSchoolAchievement().achievement1_1());
+                    assertNull(result.calculatedScore());
+                    verify(lambdaScoreCalculatorClient, never()).calculateScore(any(LambdaScoreCalculatorReqDto.class));
+                }
+            }
+
+            @Nested
             @DisplayName("회원이 원서를 제출했고 수정 권한이 없다면")
             class Context_oneseo_exist_without_edit_permission {
                 @BeforeEach

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
@@ -3,6 +3,8 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -162,6 +164,30 @@ class OneseoTempStorageServiceTest {
                             resDto.middleSchoolAchievement().gedAvgScore());
                     assertEquals(calculatedScoreResDto, resDto.calculatedScore());
                     assertEquals(step, resDto.step());
+                }
+            }
+
+            @Nested
+            @DisplayName("middleSchoolAchievement가 빈 객체로 주어지면")
+            class Context_with_empty_middle_school_achievement {
+                private final OneseoTempReqDto emptyAchievementReqDto = OneseoTempReqDto.builder()
+                        .graduationType(GraduationType.GED).graduationDate("2026-01").address("광주광역시 광산구 송정동 상무대로 312")
+                        .detailAddress("101동 1001호").profileImg("https://example.com/image.jpg")
+                        .middleSchoolAchievement(MiddleSchoolAchievementReqDto.builder().build())
+                        .firstDesiredMajor(Major.SW).secondDesiredMajor(Major.AI).thirdDesiredMajor(Major.IOT).build();
+
+                @BeforeEach
+                void setUp() {
+                    given(oneseoRepository.findByMember(member)).willReturn(Optional.empty());
+                }
+
+                @Test
+                @DisplayName("Lambda 점수 계산을 호출하지 않고 calculatedScore로 null을 반환한다")
+                void it_skips_lambda_call_and_returns_null_calculated_score() {
+                    FoundOneseoResDto result = oneseoTempStorageService.execute(emptyAchievementReqDto, step, memberId);
+
+                    assertNull(result.calculatedScore());
+                    verify(lambdaScoreCalculatorClient, never()).calculateScore(any(LambdaScoreCalculatorReqDto.class));
                 }
             }
 


### PR DESCRIPTION
## 문제

원서 임시저장(`POST /oneseo/v3/temp-storage?step=2`) 시 `middleSchoolAchievement`가 `null`이 아닌 **빈 객체(`{}`, 모든 필드 null)** 로 오는 경우, `OneseoTempStorageService.calculateScore()`의 `achievement == null` 체크를 통과해버려서 모든 필드가 null인 요청 그대로 Lambda 점수 계산 API(`hello-score-calc`)를 호출하고, Lambda가 이를 `400 Bad Request`로 거절했습니다.

실제로 GED(검정고시) 전형 지원자가 원서 작성 2단계(성적 입력 전)에서 임시저장할 때마다 재현되는 것을 스테이지 환경에서 확인했습니다. Discord 모니터링 알림과 브라우저 Network 탭 양쪽에서 동일 증상을 확인했습니다.

```
[STAGE 환경] 500에러 발생
Feign 클라이언트 오류 - 메서드: LambdaScoreCalculatorClient#calculateScore(LambdaScoreCalculatorReqDto),
HTTP 메서드: POST, 상태: 400, 이유: Bad Request
```

## 원인

```java
private CalculatedScoreResDto calculateScore(OneseoTempReqDto reqDto) {
    MiddleSchoolAchievementReqDto achievement = reqDto.middleSchoolAchievement();
    if (achievement == null) {
        return null;
    }
    ...
}
```

`{}`가 Jackson에 의해 역직렬화되면 "필드가 전부 null인 비어있지 않은 객체"가 되므로 `achievement == null` 체크만으로는 이 케이스를 걸러내지 못합니다.

## 수정

`achievement`의 모든 필드가 비어있는 경우(빈 `MiddleSchoolAchievementReqDto`와 동일한 경우)도 `null`과 동일하게 취급해 Lambda 호출을 건너뛰도록 수정했습니다.

```java
private static final MiddleSchoolAchievementReqDto EMPTY_ACHIEVEMENT = MiddleSchoolAchievementReqDto.builder().build();
...
if (achievement == null || achievement.equals(EMPTY_ACHIEVEMENT)) {
    return null;
}
```

## 테스트

- `middleSchoolAchievement`가 빈 객체로 주어졌을 때 Lambda 클라이언트를 호출하지 않고 `calculatedScore`로 `null`을 반환하는 테스트 케이스 추가
- 전체 테스트 스위트 통과 확인

https://claude.ai/code/session_011c2k2HpQGcNXW7fEfusx8x